### PR TITLE
(fix) AST-3970: Fix sentry initialisation

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_URL_ORCHESTRATION_API_WS=wss://api.development.awellhealth.com/orchestration/subscriptions
 NEXT_PUBLIC_URL_ORCHESTRATION_API=https://api.development.awellhealth.com/orchestration/graphql
+NEXT_PUBLIC_SENTRY_DSN=https://1bbdb66bde11464f9330c1f4da789acf@o185275.ingest.sentry.io/6637498

--- a/next.config.js
+++ b/next.config.js
@@ -11,13 +11,6 @@ const nextConfig = {
 }
 
 const sentryWebpackPluginOptions = {
-  // Additional config options for the Sentry Webpack plugin. Keep in mind that
-  // the following options are set automatically, and overriding them is not
-  // recommended:
-  //   release, url, org, project, authToken, configFile, stripPrefix,
-  //   urlPrefix, include, ignore
-
-  silent: true, // Suppresses all logs
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.
 }
@@ -27,4 +20,4 @@ const nextPlugins = [
   (nextConfig) => withSentryConfig(nextConfig, sentryWebpackPluginOptions),
 ]
 
-module.exports = withPlugins([withImages], nextConfig)
+module.exports = withPlugins(nextPlugins, nextConfig)

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -7,12 +7,10 @@ import * as Sentry from '@sentry/nextjs'
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 
 Sentry.init({
-  dsn:
-    SENTRY_DSN ||
-    'https://1bbdb66bde11464f9330c1f4da789acf@o185275.ingest.sentry.io/6637498',
+  dsn: SENTRY_DSN,
   // Adjust this value in production, or use tracesSampler for greater control
   // TODO in future use tracesSampler
-  tracesSampleRate: 0.1,
+  tracesSampleRate: 0.5,
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -7,12 +7,10 @@ import * as Sentry from '@sentry/nextjs'
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 
 Sentry.init({
-  dsn:
-    SENTRY_DSN ||
-    'https://1bbdb66bde11464f9330c1f4da789acf@o185275.ingest.sentry.io/6637498',
+  dsn: SENTRY_DSN,
   // Adjust this value in production, or use tracesSampler for greater control
   // TODO use tracesSampler
-  tracesSampleRate: 0.1,
+  tracesSampleRate: 0.5,
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION
- sentry was not initialised (fix is in next.config.js)
- move sentry dsn to env variables