### PR TITLE
Revert "(fix) AST-4073: Awell ui-library version update"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.6.9",
-    "@awell_health/ui-library": "0.0.31",
+    "@awell_health/ui-library": "0.0.29",
     "@sentry/nextjs": "^7.9.0",
     "graphql": "^16.5.0",
     "jsonwebtoken": "^8.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@awell_health/ui-library@0.0.31":
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/@awell_health/ui-library/-/ui-library-0.0.31.tgz#913d469f3b97e5285beb909958ac54c2f7bd1b8c"
-  integrity sha512-jFQWbfqjwnAFKjd1m3C71hUs1j17DU1puskjyQOVkfL6MWFopwYse+I55xYyDtix10XuEhbwfMIsG7vRrb/k3w==
+"@awell_health/ui-library@0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@awell_health/ui-library/-/ui-library-0.0.29.tgz#ca7399e2ff8a2618ac16f1e34bd59b605089cfa4"
+  integrity sha512-+GN2YjZ6ENG64CbSQvyoHnZXcCeH7RLQby5Gzha6q7NRgdbU7WObXVnoiUwOZEGzagu1nB5eV0KvPh63rs6DYg==
   dependencies:
     date-fns "^2.29.1"
     escape-html "^1.0.3"


### PR DESCRIPTION
Reverts awell-health/hosted-pages#41
vercel doesn't want to deploy it because of commit email was not assosiated with github account