### PR TITLE
Add interval of 10 seconds to refetch SessionActivities query manually when subscription fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "codegen": "graphql-codegen --config codegen.yml"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.9",
+    "@apollo/client": "^3.7.2",
     "@awell_health/ui-library": "0.0.42",
     "@sentry/nextjs": "^7.9.0",
     "graphql": "^16.5.0",

--- a/src/hooks/useSessionActivities/useSessionActivities.ts
+++ b/src/hooks/useSessionActivities/useSessionActivities.ts
@@ -19,6 +19,8 @@ interface UsePathwayActivitiesHook {
   error?: string
 }
 
+const POLLING_DELAY = 10000 // 10 seconds
+
 export const useSessionActivities = ({
   onlyStakeholderActivities,
 }: {
@@ -61,11 +63,11 @@ export const useSessionActivities = ({
 
   // temporary solution to refetch query when subscription does not work
   useEffect(() => {
-    const myInterval = setInterval(() => {
+    const refetchQueryInterval = setInterval(() => {
       refetch()
-    }, 10000)
+    }, POLLING_DELAY)
     // clear interval on component unmount
-    return () => clearInterval(myInterval)
+    return () => clearInterval(refetchQueryInterval)
   })
 
   useEffect(() => {

--- a/src/hooks/useSessionActivities/useSessionActivities.ts
+++ b/src/hooks/useSessionActivities/useSessionActivities.ts
@@ -28,8 +28,7 @@ export const useSessionActivities = ({
     only_stakeholder_activities: onlyStakeholderActivities,
   }
   const client = useApolloClient()
-  const { data, error, loading } = useGetHostedSessionActivitiesQuery({
-    pollInterval: 10000, // refetch this query every 10 seconds
+  const { data, error, loading, refetch } = useGetHostedSessionActivitiesQuery({
     variables,
   })
 
@@ -59,6 +58,15 @@ export const useSessionActivities = ({
     sortActivitiesByDate(
       data?.hostedSessionActivities.activities as Activity[]
     ) ?? []
+
+  // temporary solution to refetch query when subscription does not work
+  useEffect(() => {
+    const myInterval = setInterval(() => {
+      refetch()
+    }, 10000)
+    // clear interval on component unmount
+    return () => clearInterval(myInterval)
+  })
 
   useEffect(() => {
     if (!isNil(onActivityCreated.data)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,19 +10,20 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@apollo/client@^3.6.9":
-  version "3.6.9"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.9.tgz#ad0ee2e3a3c92dbed4acd6917b6158a492739d94"
-  integrity sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==
+"@apollo/client@^3.7.2":
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.7.2.tgz#71b6846c1d99b81d041a1134f5679e30ec0363a0"
+  integrity sha512-ohAIpXl3mTa1Fd3GT/K37VwQJfTIuuJRp4aOlJ4q/hlx0Wxh+RqDrbn0awtVCOdhGDQN+CQQmVzIqFKn6GziXQ==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
-    "@wry/context" "^0.6.0"
+    "@wry/context" "^0.7.0"
     "@wry/equality" "^0.5.0"
     "@wry/trie" "^0.3.0"
     graphql-tag "^2.12.6"
     hoist-non-react-statics "^3.3.2"
     optimism "^0.16.1"
     prop-types "^15.7.2"
+    response-iterator "^0.2.6"
     symbol-observable "^4.0.0"
     ts-invariant "^0.10.3"
     tslib "^2.3.0"
@@ -1577,6 +1578,13 @@
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
   integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/context@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.7.0.tgz#be88e22c0ddf62aeb0ae9f95c3d90932c619a5c8"
+  integrity sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==
   dependencies:
     tslib "^2.3.0"
 
@@ -5335,6 +5343,11 @@ resolve@^2.0.0-next.3:
     is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+response-iterator@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/response-iterator/-/response-iterator-0.2.6.tgz#249005fb14d2e4eeb478a3f735a28fd8b4c9f3da"
+  integrity sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==
 
 restore-cursor@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
I tried to add [pollInterval](https://www.apollographql.com/docs/react/data/queries/#polling) and even added `startPolling` to manually start polling for graphql query but I wasn't able to test it. The query wasn't called again. I also tried [disabling strictReact](https://github.com/apollographql/apollo-client/issues/9819) in nextjs but that didn't help either.

So I implemented a manual `setInterval` function that refetches the graphql query after every 10 seconds and clears the interval when component/hook gets unmounted.

This temporarily fixes the issue. 