### PR TITLE
AST-4775 build(sentry): set AWELL_ENVIRONMENT var

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -8,6 +8,10 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 
 Sentry.init({
   dsn: SENTRY_DSN,
+  // These environment EnvVars are set automatically on Vercel and do not need to be configured
+  // They ensure that the correct environment is set in Sentry as this is a known issue
+  // See https://github.com/getsentry/sentry-javascript/issues/6993 for latest
+  environment: process.env.NEXT_PUBLIC_AWELL_ENVIRONMENT,
   // Adjust this value in production, or use tracesSampler for greater control
   // TODO in future use tracesSampler
   tracesSampleRate: 0.5,

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -35,7 +35,9 @@ export class ErrorBoundary extends React.Component<
   render(): React.ReactNode {
     const { hasError, error, info } = this.state
     const { children } = this.props
-    const showStack = process.env.NODE_ENV === 'development'
+    const showStack =
+      process.env.NODE_ENV === 'development' ||
+      process.env.NEXT_PUBLIC_AWELL_ENVIRONMENT === 'staging'
 
     if (hasError) {
       if (showStack) {


### PR DESCRIPTION
Changes:
- added NEXT_PUBLIC_AWELL_ENVIRONMENT with environment values to various Vercel deployments (e.g. staging, sandbox, production, production-us)
- use this EnvVar in Sentry config for app to ensure that environment is correctly tagged

This is a workaround since there is no simple way to ensure that Preview builds in Vercel are not tagged as production --  NODE_ENV value (which Sentry natively relies on for tagging) in Preview builds are set to 'production' automatically 

AST-4775