### PR TITLE
chore(ci): update checkout action to v3

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -7,13 +7,13 @@ jobs:
   merge-release-content-to-production:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set Git config
       run: |
-          git config --local user.email "mohsinhayat104@gmail.com" # for testing only, we can use any email that has permissions on this repo
-          git config --local user.name "mohsinht" # for testing only, we can use any username that has permissions on this repo
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
     - name: Merge release content into production
       run: |
         git fetch --unshallow
@@ -25,13 +25,13 @@ jobs:
   merge-release-content-to-production-us:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set Git config
       run: |
-          git config --local user.email "mohsinhayat104@gmail.com" # for testing only, we can use any email that has permissions on this repo
-          git config --local user.name "mohsinht" # for testing only, we can use any username that has permissions on this repo
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
     - name: Merge release content into production-us branch
       run: |
         git fetch --unshallow

--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -7,13 +7,13 @@ jobs:
   merge-release-content-to-sandbox:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set Git config
       run: |
-          git config --local user.email "mohsinhayat104@gmail.com" # for testing only, we can use any email that has permissions on this repo
-          git config --local user.name "mohsinht" # for testing only, we can use any username that has permissions on this repo
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
     - name: Merge release content into sandbox
       run: |
         git fetch --unshallow

--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -9,13 +9,13 @@ jobs:
   merge-release-content-to-staging:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set Git config
       run: |
-          git config --local user.email "mohsinhayat104@gmail.com" # for testing only, we can use any email that has permissions on this repo
-          git config --local user.name "mohsinht" # for testing only, we can use any username that has permissions on this repo
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
     - name: Set env
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Staging release message


### PR DESCRIPTION
Reason:
- checkout action v2 uses node@12 which will be deprecated by github for actions this summer

Changes:
- update checkout action to v3 in all action config files (uses node@16)
- replace `mohsin` with `github bot` as user doing releases (see https://github.com/actions/checkout/pull/1184 for context)