### PR TITLE
AST-4886: translations for AHP

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,8 +24,7 @@ import { NextPageWithLayout } from './_app'
 import { HostedSessionLayout } from '../src/layouts'
 import { SuccessPage } from '../src/components/SuccessPage'
 import { CancelPage } from '../src/components/CancelPage'
-
-const AWELL_BRAND_COLOR = '#004ac2'
+import { AWELL_BRAND_COLOR } from '../src/config'
 
 const Home: NextPageWithLayout = () => {
   const { t } = useTranslation()

--- a/pages/l/[hostedPagesLinkId].tsx
+++ b/pages/l/[hostedPagesLinkId].tsx
@@ -3,6 +3,9 @@ import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { StartHostedActivitySessionFlow } from '../../src/components/StartHostedActivitySessionFlow'
 import { StartHostedActivitySessionParams } from '../../types'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { ThemeProvider } from '@awell_health/ui-library'
+import { AWELL_BRAND_COLOR } from '../../src/config'
 
 /**
  * Purpose of this page is to support shortened URLs i.e. 'hosted-pages.awellhealth.com/l/<hostedPagesLinkId>'
@@ -16,7 +19,9 @@ const HostedPagesLink: NextPage = () => {
   // if it is a shortened URL
   if (!isNil(hostedPagesLinkId) && typeof hostedPagesLinkId === 'string') {
     return (
-      <StartHostedActivitySessionFlow hostedPagesLinkId={hostedPagesLinkId} />
+      <ThemeProvider accentColor={AWELL_BRAND_COLOR}>
+        <StartHostedActivitySessionFlow hostedPagesLinkId={hostedPagesLinkId} />
+      </ThemeProvider>
     )
   }
 
@@ -24,3 +29,11 @@ const HostedPagesLink: NextPage = () => {
 }
 
 export default HostedPagesLink
+
+export async function getServerSideProps({ locale }: { locale: string }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'])),
+    },
+  }
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,4 +1,5 @@
 {
+  "errors": { "app_error": "Oops, something went wrong. Please try again." },
   "activities": {
     "loading_error": "Something went wrong while loading your activities.",
     "loading": "Loading activity...",
@@ -26,17 +27,23 @@
     },
     "checklist": {
       "cta_submit": "Submit",
+      "loading": "Loading checklist...",
       "loading_error": "Something went wrong while loading the checklist.",
       "saving_error": "Checklist submission failed."
     }
   },
   "preview": {
-    "cta": "Start preview"
+    "cta": "Try it out"
   },
   "seo": {
     "loading_title": "Loading",
     "title": "Awell Activities",
     "description": "Complete activities in your care flow with Awell hosted pages."
+  },
+  "link_page": {
+    "loading": "Hang on, we are starting your session.",
+    "loading_error": "Oops, we could not start a session for you.",
+    "try_again": "Try again"
   },
   "session": {
     "authentication_loading": "Authenticating, please wait.",
@@ -44,7 +51,7 @@
     "loading_error": "Something went wrong while loading your session.",
     "loading": "Loading session...",
     "redirecting_to_next_page": "Redirecting you in a moment.",
-    "all_activities_completed": "You have completed all your care activities. You can close this page now.",
+    "all_activities_completed": "You have completed all your activities. You can close this page now.",
     "session_canceled": "Your session has been cancelled.",
     "try_again": "Try again",
     "close_modal": {

--- a/public/locales/et/common.json
+++ b/public/locales/et/common.json
@@ -1,4 +1,5 @@
 {
+  "errors": { "app_error": "Oops, something went wrong. Please try again." },
   "activities": {
     "loading_error": "Midagi läks tegevuste laadimisel valesti.",
     "loading": "Tegevuse laadimine...",
@@ -26,13 +27,23 @@
     },
     "checklist": {
       "cta_submit": "Esita vastused",
+      "loading": "Laadimine...",
       "loading_error": "Midagi läks nimekirja laadimisel valesti.",
       "saving_error": "Nimekirja esitamine ebaõnnestus."
     }
   },
+  "preview": {
+    "cta": "Try it out"
+  },
   "seo": {
+    "loading_title": "Laadimine...",
     "title": "Awelli tegevused",
     "description": "Viige oma raviteekonna tegevused lõpule Awelli hostitud lehtedega."
+  },
+  "link_page": {
+    "loading": "Hang on, we are starting your session.",
+    "loading_error": "Oops, we could not start a session for you.",
+    "try_again": "Proovi uuesti"
   },
   "session": {
     "authentication_loading": "Autentimine, palun oodake.",
@@ -40,6 +51,8 @@
     "loading_error": "Midagi läks seansi laadimisel valesti.",
     "loading": "Seansi laadimine...",
     "redirecting_to_next_page": "Teid suunatakse hetke pärast ümber.",
+    "all_activities_completed": "You have completed all your activities. You can close this page now.",
+    "session_canceled": "Your session has been cancelled.",
     "try_again": "Proovi uuesti",
     "close_modal": {
       "title": "Soovid pöördumise täitmise pooleli jätta?",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,4 +1,7 @@
 {
+  "errors": {
+    "app_error": "Oups, quelque chose s'est mal passé. Veuillez réessayer."
+  },
   "activities": {
     "loading_error": "Something went wrong while loading activities.",
     "loading": "Loading activity...",
@@ -26,13 +29,23 @@
     },
     "checklist": {
       "cta_submit": "Submit",
+      "loading": "Loading checklist",
       "loading_error": "Something went wrong while loading checklist.",
       "saving_error": "Checklist submission failed."
     }
   },
+  "preview": {
+    "cta": "Try it out"
+  },
   "seo": {
+    "loading_title": "Loading...",
     "title": "Awell Activities",
     "description": "Complete activities in your care flow with Awell hosted pages."
+  },
+  "link_page": {
+    "loading": "Hang on, we are starting your session.",
+    "loading_error": "Oops, we could not start a session for you.",
+    "try_again": "Réessayer"
   },
   "session": {
     "authentication_loading": "Authenticating, please wait.",
@@ -40,6 +53,8 @@
     "loading_error": "Something when wrong while loading session.",
     "loading": "Loading session...",
     "redirecting_to_next_page": "Redirecting you in a moment.",
+    "all_activities_completed": "You have completed all your activities. You can close this page now.",
+    "session_canceled": "Your session has been cancelled.",
     "try_again": "Réessayer",
     "close_modal": {
       "title": "Are you sure you want to cancel your session?",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -1,4 +1,7 @@
 {
+  "errors": {
+    "app_error": "Oeps, er is iets misgelopen. Probeer het opnieuw."
+  },
   "activities": {
     "loading_error": "Er is iets misgelopen bij het ophalen van de volgende aciviteit.",
     "loading": "Activiteit laden...",
@@ -26,13 +29,23 @@
     },
     "checklist": {
       "cta_submit": "Klaar",
+      "loading": "Checklist laden...",
       "loading_error": "Er is iets misgelopen bij het ophalen van de checklist.",
       "saving_error": "Checklist kon niet verzonden worden."
     }
   },
+  "preview": {
+    "cta": "Probeer het uit"
+  },
   "seo": {
+    "loading_title": "Laden...",
     "title": "Awell Activiteiten",
     "description": "Voltooi activiteiten in uw zorgpad met Awell hosted pages."
+  },
+  "link_page": {
+    "loading": "Even geduld, we starten voor jouw een sessie.",
+    "loading_error": "Oeps, er is iets misgelopen tijdens het laden van jouw sessie.",
+    "try_again": "Opnieuw proberen"
   },
   "session": {
     "authentication_loading": "Authenticeren, even geduld.",
@@ -40,6 +53,8 @@
     "loading_error": "Er is iets misgelopen bij het laden van de sessie.",
     "loading": "Sessie laden...",
     "redirecting_to_next_page": "Je wordt meteen doorverwezen.",
+    "all_activities_completed": "Je hebt alle activiteiten voltooid. Je kan deze pagina nu sluiten.",
+    "session_canceled": "Je sessie werd geannuleerd.",
     "try_again": "Opnieuw proberen",
     "close_modal": {
       "title": "Ben je zeker dat je de sessie wil afsluiten?",

--- a/src/components/Checklist/Checklist.tsx
+++ b/src/components/Checklist/Checklist.tsx
@@ -22,8 +22,9 @@ export const Checklist: FC<ChecklistProps> = ({ activity }) => {
   })
 
   if (loading) {
-    return <LoadingPage title="Loading activity" />
+    return <LoadingPage title={t('activities.checklist.loading')} />
   }
+
   if (error) {
     return (
       <ErrorPage

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 import { ErrorPage } from '../ErrorPage'
 import { ErrorBoundaryProps, ErrorInfo, ErrorBoundaryState } from './types'
 import { reportErrorToSentry } from './reportErrorToSentry'
+import { withTranslation } from 'next-i18next'
 
 // https://reactjs.org/docs/error-boundaries.html
-export class ErrorBoundary extends React.Component<
+class ErrorBoundary extends React.Component<
   ErrorBoundaryProps,
   ErrorBoundaryState
 > {
@@ -43,20 +44,22 @@ export class ErrorBoundary extends React.Component<
       if (showStack) {
         return (
           <article style={{ whiteSpace: 'pre-wrap' }}>
-            <ErrorPage title="Oops, something went wrong">
+            <ErrorPage title={this.props.t('errors.app_error')}>
               <div>{error?.toString()}</div>
               {showStack && <div>{info?.componentStack}</div>}
             </ErrorPage>
           </article>
         )
       }
-      return <ErrorPage title="Oops, something went wrong" />
+      return <ErrorPage title={this.props.t('errors.app_error')} />
     }
 
     return (
-      <div id="error-boundry" style={this.props.style}>
+      <div id="error-boundary" style={this.props.style}>
         {children}
       </div>
     )
   }
 }
+
+export default withTranslation()(ErrorBoundary)

--- a/src/components/ErrorBoundary/index.ts
+++ b/src/components/ErrorBoundary/index.ts
@@ -1,1 +1,1 @@
-export { ErrorBoundary } from './ErrorBoundary'
+export { default as ErrorBoundary } from './ErrorBoundary'

--- a/src/components/ErrorBoundary/types.ts
+++ b/src/components/ErrorBoundary/types.ts
@@ -1,10 +1,11 @@
+import { WithTranslation } from 'next-i18next'
 import React from 'react'
 
 export interface ErrorInfo {
   componentStack: string
 }
 
-export interface ErrorBoundaryProps {
+export interface ErrorBoundaryProps extends WithTranslation {
   onError?: (error: Error) => void
   children: React.ReactNode
   pathwayId?: string

--- a/src/components/StartHostedActivitySessionFlow/StartHostedActivitySessionFlow.tsx
+++ b/src/components/StartHostedActivitySessionFlow/StartHostedActivitySessionFlow.tsx
@@ -1,4 +1,3 @@
-import { HorizontalSpinner, Text } from '@awell_health/ui-library'
 import { isNil } from 'lodash'
 import { useRouter } from 'next/router'
 import { FC, useEffect } from 'react'
@@ -6,6 +5,8 @@ import useSWR from 'swr'
 import { StartHostedActivitySessionParams } from '../../../types'
 import { ErrorPage } from '../ErrorPage'
 import { LoadingPage } from '../LoadingPage'
+import { useTranslation } from 'next-i18next'
+import classes from './startHostedActivitySessionFlow.module.css'
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json())
 
@@ -15,11 +16,17 @@ export const StartHostedActivitySessionFlow: FC<
   StartHostedActivitySessionFlowProps
 > = ({ hostedPagesLinkId }): JSX.Element => {
   const router = useRouter()
+  const { t } = useTranslation()
 
   const { data, error } = useSWR(
     `/api/startHostedActivitySessionViaHostedPagesLink/${hostedPagesLinkId}`,
     fetcher
   )
+
+  const retry = () => {
+    window.location.reload()
+  }
+
   useEffect(() => {
     if (!isNil(data?.sessionId)) {
       router.replace(`../?sessionId=${data?.sessionId}`)
@@ -28,9 +35,15 @@ export const StartHostedActivitySessionFlow: FC<
 
   if (error || !isNil(data?.error)) {
     return (
-      <ErrorPage title="Something went wrong while fetching your activities." />
+      <div className={classes.container}>
+        <ErrorPage title={t('link_page.loading_error')} onRetry={retry} />
+      </div>
     )
   }
 
-  return <LoadingPage title="Fetching activities. Please wait." />
+  return (
+    <div className={classes.container}>
+      <LoadingPage title={t('link_page.loading')} />
+    </div>
+  )
 }

--- a/src/components/StartHostedActivitySessionFlow/startHostedActivitySessionFlow.module.css
+++ b/src/components/StartHostedActivitySessionFlow/startHostedActivitySessionFlow.module.css
@@ -1,7 +1,4 @@
 .container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
+    margin-top: var(--awell-spacing-12)
 }
   

--- a/src/config/awell.ts
+++ b/src/config/awell.ts
@@ -1,0 +1,1 @@
+export const AWELL_BRAND_COLOR = '#004ac2'

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,1 @@
+export { AWELL_BRAND_COLOR } from './awell'


### PR DESCRIPTION
https://www.loom.com/share/e717216d06334608970ad44c21b116a3

**In this MR:**
- Make sure all strings are translatable
- Wrap `l/[hostedPagesLinkId].tsx` page in ThemeProvider + make sure translations are loaded with `getServerSideProps`
- Add translations to ErrorBoundary

**Note:**
Not all translations in all languages are added in this MR but all keys are present in all languages so it is easy to add translations later if needed. Primary language we need to support right now is English.