### PR TITLE
fix(): use getStaticProps instead of getServerSideProps in hosted pages link page

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = {
   i18n: {
     // These are all the locales you want to support in
@@ -8,6 +10,6 @@ module.exports = {
     // information detected from either the locale based domain or locale path as described above.
     localeDetection: false,
     defaultLocale: 'en',
-    localePath: './public/locales',
+    localePath: path.resolve('./public/locales'),
   },
 }

--- a/pages/l/[hostedPagesLinkId].tsx
+++ b/pages/l/[hostedPagesLinkId].tsx
@@ -30,7 +30,7 @@ const HostedPagesLink: NextPage = () => {
 
 export default HostedPagesLink
 
-export async function getServerSideProps({ locale }: { locale: string }) {
+export async function getStaticProps({ locale }: { locale: string }) {
   return {
     props: {
       ...(await serverSideTranslations(locale, ['common'])),

--- a/pages/l/[hostedPagesLinkId].tsx
+++ b/pages/l/[hostedPagesLinkId].tsx
@@ -1,11 +1,12 @@
 import { isNil } from 'lodash'
-import type { NextPage } from 'next'
+import type { GetStaticPaths, NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { StartHostedActivitySessionFlow } from '../../src/components/StartHostedActivitySessionFlow'
 import { StartHostedActivitySessionParams } from '../../types'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { ThemeProvider } from '@awell_health/ui-library'
 import { AWELL_BRAND_COLOR } from '../../src/config'
+import { NoSSRComponent } from '../../src/components/NoSSR'
 
 /**
  * Purpose of this page is to support shortened URLs i.e. 'hosted-pages.awellhealth.com/l/<hostedPagesLinkId>'
@@ -13,19 +14,15 @@ import { AWELL_BRAND_COLOR } from '../../src/config'
 const HostedPagesLink: NextPage = () => {
   const router = useRouter()
 
-  // if it is a stakeholder session flow (redirected after validation)
   const { hostedPagesLinkId } = router.query as StartHostedActivitySessionParams
 
-  // if it is a shortened URL
-  if (!isNil(hostedPagesLinkId) && typeof hostedPagesLinkId === 'string') {
-    return (
+  return (
+    <NoSSRComponent>
       <ThemeProvider accentColor={AWELL_BRAND_COLOR}>
         <StartHostedActivitySessionFlow hostedPagesLinkId={hostedPagesLinkId} />
       </ThemeProvider>
-    )
-  }
-
-  return <></>
+    </NoSSRComponent>
+  )
 }
 
 export default HostedPagesLink
@@ -35,5 +32,12 @@ export async function getStaticProps({ locale }: { locale: string }) {
     props: {
       ...(await serverSideTranslations(locale, ['common'])),
     },
+  }
+}
+
+export const getStaticPaths: GetStaticPaths<{ slug: string }> = async () => {
+  return {
+    paths: [], //indicates that no page needs be created at build time
+    fallback: 'blocking', //indicates the type of fallback
   }
 }

--- a/src/components/NoSSR.tsx
+++ b/src/components/NoSSR.tsx
@@ -5,7 +5,7 @@ const Wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   return <>{children}</>
 }
 /**
- * Disable SSR on the whole app.
+ * This component disables SSR on all its chilren components.
  */
 export const NoSSRComponent = dynamic(Promise.resolve(Wrapper), {
   ssr: false,


### PR DESCRIPTION
https://github.com/i18next/next-i18next/issues/1552

This `getServerSideProps` is not working as expected. 

See these errors in Vercel logs:
```error
Error: ENOENT: no such file or directory, scandir '/var/task/public/locales/en'
    at Object.readdirSync (node:fs:1438:3)
    at getLocaleNamespaces (/var/task/node_modules/next-i18next/dist/commonjs/config/createConfig.js:214:16)
    at /var/task/node_modules/next-i18next/dist/commonjs/config/createConfig.js:231:20
    at Array.map (<anonymous>)
    at getNamespaces (/var/task/node_modules/next-i18next/dist/commonjs/config/createConfig.js:230:44)
    at createConfig (/var/task/node_modules/next-i18next/dist/commonjs/config/createConfig.js:271:29)
    at _callee$ (/var/task/node_modules/next-i18next/dist/commonjs/serverSideTranslations.js:201:53)
    at tryCatch (/var/task/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:86:17)
    at Generator._invoke (/var/task/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:66:24)
    at Generator.next (/var/task/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:117:21) {
  errno: -2,
  syscall: 'scandir',
  path: '/var/task/public/locales/en',
  page: '/l/[hostedPagesLinkId]'
}
```