### PR TITLE
fix(scroll): fix scroll on Y overflow in HostedSessionLayout

### DIFF
--- a/src/layouts/HostedSessionLayout.tsx
+++ b/src/layouts/HostedSessionLayout.tsx
@@ -20,7 +20,7 @@ export const HostedSessionLayout: FC<LayoutProps> = ({ children }) => {
                 Styles need to be applied to the ErrorBoundary
                 to make sure layout is rendered correctly. 
               */}
-              <ErrorBoundary style={{ height: '100%' }}>
+              <ErrorBoundary style={{ height: '100%', overflowY: 'auto' }}>
                 {children}
               </ErrorBoundary>
             </NoSSRComponent>


### PR DESCRIPTION
Problem:
- when viewing the page on a mobile device in landscape mode, the content is not scrollable

Solution:
- allow scrolling on the content

Changes:
- add overflow-y: auto to the ErrorBoundary in the HostedSessionLayout component