### PR TITLE
chore(ui-library): bump ui-library to 0.1.13 and minor cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hosted-pages",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.2",
-    "@awell_health/ui-library": "0.1.11",
+    "@awell_health/ui-library": "0.1.13",
     "@formsort/react-embed": "^3.1.1",
     "@sentry/nextjs": "7.34.0",
     "date-fns": "^2.29.3",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -75,7 +75,7 @@
     "invalid_url": "Invalid URL: URL must contain `sessionId` parameter.",
     "loading_error": "Something went wrong while loading your session.",
     "loading": "Loading session...",
-    "redirecting_to_next_page": "Redirecting you in a moment.",
+    "redirecting_to_next_page": "Redirecting you in a moment...",
     "all_activities_completed": "You have completed all your activities. You can close this page now.",
     "session_canceled": "Your session has been cancelled.",
     "try_again": "Try again",

--- a/src/components/Activities/ActivityContainer.tsx
+++ b/src/components/Activities/ActivityContainer.tsx
@@ -6,7 +6,6 @@ import { ErrorPage } from '../ErrorPage'
 import { ActivityProvider } from '../../hooks/activityNavigation'
 import { Activities } from './Activities'
 import { ErrorBoundary } from '../ErrorBoundary'
-import classes from './activityContainer.module.css'
 
 export const ActivityContainer: FC<{ pathwayId: string }> = ({ pathwayId }) => {
   const { t } = useTranslation()

--- a/src/components/Activities/ActivityDetails.tsx
+++ b/src/components/Activities/ActivityDetails.tsx
@@ -1,5 +1,4 @@
-import { FC, useEffect } from 'react'
-import { toast } from 'react-toastify'
+import { FC } from 'react'
 import { Activity } from './types'
 import { useTranslation } from 'next-i18next'
 import { Form } from '../Form'

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,10 +66,10 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@awell_health/ui-library@0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@awell_health/ui-library/-/ui-library-0.1.11.tgz#ca2f926e2da00ddc91622e32739599d49548eec7"
-  integrity sha512-iYO5rxuO6+3FkqRNhgMHtokHeTutiBoYPbOWVNEG2YD8miiATYLV0PLRWuyzcsICHgeOSr4mavrVrtkTzD66cg==
+"@awell_health/ui-library@0.1.13":
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/@awell_health/ui-library/-/ui-library-0.1.13.tgz#dc89d92f1fdfc174b871d0c19abd1d3da9781413"
+  integrity sha512-R93leJ5b0KGV+Hy1N/NJKk2/f22KnNNjtBlbvmyXiALbL44eKkkw0e2m/+ZvItjTe1R8kPxZgjN2kvUagp5cEQ==
   dependencies:
     "@calcom/embed-react" "^1.0.10"
     "@heroicons/react" "^2.0.13"


### PR DESCRIPTION
Changes:
- bump ui-library to v0.1.13
- remove unused imports
- minor change to translation string for redirect