### PR TITLE
fix(i18n): fix invalid url translation

### DIFF
--- a/src/services/authentication/AuthenticationProvider.tsx
+++ b/src/services/authentication/AuthenticationProvider.tsx
@@ -55,7 +55,7 @@ export const AuthenticationProvider: FC<AuthenticationProviderProps> = ({
   }
 
   if (router.isReady && !router.query.sessionId) {
-    return <ErrorPage title={t('session.error_invalid_url')} />
+    return <ErrorPage title={t('session.invalid_url')} />
   }
 
   // Wait while token is being generated


### PR DESCRIPTION
Changes:
- translation string is `invalid_url` not `error_invalid_url`