### PR TITLE
fix: remove session activity updated event as it is not needed

### DIFF
--- a/src/hooks/activityNavigation/ActivityProvider.tsx
+++ b/src/hooks/activityNavigation/ActivityProvider.tsx
@@ -20,7 +20,7 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({
   const [currentActivityId, setCurrentActivityId] = useState<string>('')
 
   const findCurrentActivity = (): Activity | undefined => {
-    if (activities.length === 0) {
+    if (activities.length === 0 || currentActivityId === '') {
       return undefined
     }
     return activities.find(({ id }) => id === currentActivityId)

--- a/src/hooks/useSessionActivities/useSessionActivities.ts
+++ b/src/hooks/useSessionActivities/useSessionActivities.ts
@@ -6,7 +6,6 @@ import { updateQuery } from '../../services/graphql'
 import {
   Activity,
   useOnSessionActivityCompletedSubscription,
-  useOnSessionActivityUpdatedSubscription,
   useOnSessionActivityCreatedSubscription,
   useGetHostedSessionActivitiesQuery,
   GetHostedSessionActivitiesDocument,
@@ -57,7 +56,6 @@ export const useSessionActivities = ({
    * returned via these subscriptions will automatically be updated in the cache,
    * which means the `activities` array will also be automatically updated.
    */
-  useOnSessionActivityUpdatedSubscription({ variables })
   useOnSessionActivityCompletedSubscription({ variables })
 
   const sortActivitiesByDate = (activities: Activity[]): Activity[] => {


### PR DESCRIPTION
Why is this change needed?: https://www.loom.com/share/d6b407d072d54d9b86b20f4830889d79

**Problem:**   
- SessionActivityUpdated event listens to the changes in `Activity`. But this has a drawback. The changes to an activity are applied one at a time. For example, when we fill a form, then a sub-activity is added to the `Activity` document. Which triggers `ActivityUpdated` event.
- At this stage when sub-activity is added, the subscription sends a message to client that this `Activity` has been updated with some new data. Client updates the cache with the new `Activity` data.
- Then the `ActivityCompleted` event is triggered as `Activity` is marked as 'Done'.

But what happens if `ActivityUpdated` event happens AFTER `ActivityCompleted` ? Then the activity is first marked as `Done` by the `ActivityCompleted` event and then the activity is marked `Active` by the `ActivityUpdated` event. This leaves the Hosted Pages app in a wrong state.

**Solution:** 
 - Remove `ActivityUpdated` event from the app as it is not required. We only need to listen to statuses of Activities, not their other properties.