### PR TITLE
DropboxSign signed data point

### DIFF
--- a/src/components/Extension/DropboxSignExtension/actions/EmbeddedSigningAction/EmbeddedSigningAction.tsx
+++ b/src/components/Extension/DropboxSignExtension/actions/EmbeddedSigningAction/EmbeddedSigningAction.tsx
@@ -55,7 +55,7 @@ export const EmbeddedSigningAction: FC<EmbeddedSigningActionActionProps> = ({
         })
 
         client.on('sign', () => {
-          onSubmit(activity_id)
+          onSubmit(activity_id, { signed: true })
         })
       })
   }
@@ -80,7 +80,9 @@ export const EmbeddedSigningAction: FC<EmbeddedSigningActionActionProps> = ({
           }}
         >
           <p>The sign URL for this signature request is expired.</p>
-          <Button onClick={() => onSubmit(activity_id)}>Continue</Button>
+          <Button onClick={() => onSubmit(activity_id, { signed: false })}>
+            Continue
+          </Button>
         </div>
       ) : (
         <Button onClick={singDocument}>Sign document</Button>

--- a/src/components/Extension/DropboxSignExtension/actions/EmbeddedSigningAction/EmbeddedSigningAction.tsx
+++ b/src/components/Extension/DropboxSignExtension/actions/EmbeddedSigningAction/EmbeddedSigningAction.tsx
@@ -32,7 +32,7 @@ export const EmbeddedSigningAction: FC<EmbeddedSigningActionActionProps> = ({
    */
   const decodedSignUrl = he.decode(signUrl)
 
-  const settingsData = useMemo(() => mapSettingsToObject(settings), [fields])
+  const settingsData = useMemo(() => mapSettingsToObject(settings), [settings])
 
   const { testMode, clientId } = validateSettings(settingsData)
 

--- a/src/components/Extension/DropboxSignExtension/actions/EmbeddedSigningAction/EmbeddedSigningAction.tsx
+++ b/src/components/Extension/DropboxSignExtension/actions/EmbeddedSigningAction/EmbeddedSigningAction.tsx
@@ -54,6 +54,10 @@ export const EmbeddedSigningAction: FC<EmbeddedSigningActionActionProps> = ({
           skipDomainVerification: true,
         })
 
+        /*
+         ! Needs handling of all events; currently only `sign` event is handled
+         ! https://github.com/hellosign/hellosign-embedded/wiki/API-Documentation-(v2)#events
+         */
         client.on('sign', () => {
           onSubmit(activity_id, { signed: true })
         })

--- a/src/components/Extension/DropboxSignExtension/actions/EmbeddedSigningAction/hooks/useCompleteEmbeddedSigningAction.tsx
+++ b/src/components/Extension/DropboxSignExtension/actions/EmbeddedSigningAction/hooks/useCompleteEmbeddedSigningAction.tsx
@@ -5,8 +5,8 @@ export const useCompleteEmbeddedSigningAction = () => {
   const { isSubmitting, onSubmit: _onSubmit } = useCompleteExtensionActivity()
 
   const onSubmit = useCallback(
-    async (activityId: string) => {
-      const dataPoints: DataPoints = []
+    async (activityId: string, { signed }: { signed: boolean }) => {
+      const dataPoints: DataPoints = [{ key: 'signed', value: String(signed) }]
 
       return _onSubmit(activityId, dataPoints)
     },


### PR DESCRIPTION
Set `signed` data point according to signing status.

**Needs handling of all events (https://github.com/hellosign/hellosign-embedded/wiki/API-Documentation-(v2)#events). Currently only `sign` event is handled.**