### PR TITLE
fix(uploadaction): correct fallback check for uploadPreset value

### DIFF
--- a/src/components/Extension/CloudinaryExtension/actions/UploadFilesAction/UploadFilesAction.tsx
+++ b/src/components/Extension/CloudinaryExtension/actions/UploadFilesAction/UploadFilesAction.tsx
@@ -10,6 +10,7 @@ import type {
   UploadFilesFields,
 } from '../../types'
 import type { ExtensionActivityRecord } from '../../../types'
+import { isEmpty, isNil } from 'lodash'
 
 interface UploadFilesActionProps {
   activityDetails: ExtensionActivityRecord
@@ -56,7 +57,11 @@ export const UploadFilesAction: FC<UploadFilesActionProps> = ({
   return (
     <CloudinaryUpload
       cloudName={cloudName}
-      uploadPreset={uploadPresetActionFields ?? uploadPresetSettings}
+      uploadPreset={
+        !isEmpty(uploadPresetActionFields) && !isNil(uploadPresetActionFields)
+          ? uploadPresetActionFields
+          : uploadPresetSettings
+      }
       folder={folderActionFields ?? folderSettings}
       tags={tagsArray}
       context={{


### PR DESCRIPTION
Changes:
- for the Cloudinary upload activity, we want to fall back to the extension settings value for uploadPreset if the action-level value is also not empty (i.e. not just undefined/null)