### PR TITLE
TP-215 fix(activities): sort activities by date when updating via subscription

### DIFF
--- a/src/hooks/useSessionActivities/useSessionActivities.ts
+++ b/src/hooks/useSessionActivities/useSessionActivities.ts
@@ -111,7 +111,10 @@ export const useSessionActivities = ({
       const {
         data: { sessionActivityCreated },
       } = onActivityCreated
-      const updatedActivities = [sessionActivityCreated, ...activities]
+      const updatedActivities = sortActivitiesByDate([
+        sessionActivityCreated,
+        ...activities,
+      ])
       const updatedQuery = updateQuery<
         GetHostedSessionActivitiesQuery,
         Array<Activity>


### PR DESCRIPTION
When activities are added to the session via subscription, ensure that we sort the new activities by date order as well.

closes TP-215