### PR TITLE
ci: echoeshq deployment status

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish-release:
     runs-on: ubuntu-latest
+    outputs:
+      deployment_id: ${{ steps.publish-release.outputs.deployment_id }}
     steps:
       - name: Checkout
         with:
@@ -21,3 +23,21 @@ jobs:
         run: ./scripts/publish_release.sh
         env:
           ECHOESHQ_API_KEY_RELEASES: ${{ secrets.ECHOESHQ_API_KEY_RELEASES }}
+
+  fail-release:
+    runs-on: ubuntu-latest
+    needs: publish-release
+    steps:
+      - name: Checkout
+        with:
+          fetch-depth: 0
+        uses: actions/checkout@v2
+
+      - name: Install packages
+        run: sudo apt-get install -y libdatetime-perl
+
+      - name: Fail release
+        run: ./scripts/fail_release.sh
+        env:
+          ECHOESHQ_API_KEY_RELEASES: ${{ secrets.ECHOESHQ_API_KEY_RELEASES }}
+          ECHOESHQ_DEPLOYMENT_ID: ${{ needs.publish-release.outputs.deployment_id }}

--- a/scripts/fail_release.sh
+++ b/scripts/fail_release.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+ECHOES_API_ENDPOINT="https://api.echoeshq.com/v1/signals/deployments"
+API_KEY="${ECHOESHQ_API_KEY_RELEASES}"
+
+curl --silent --show-error --fail --location --request POST ${ECHOES_API_ENDPOINT}/${ECHOESHQ_DEPLOYMENT_ID}/status \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer '"${API_KEY}"'' \
+--data-raw '{
+    "status": "failure"
+}'

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ECHOES_API_ENDPOINT="https://api.echoeshq.com/v1/signals/releases"
+ECHOES_API_ENDPOINT="https://api.echoeshq.com/v1/signals/deployments"
 API_KEY="${ECHOESHQ_API_KEY_RELEASES}"
 
 # get the 2 latest tags
@@ -19,7 +19,7 @@ commitsJSON=$(jq --compact-output --null-input '$ARGS.positional' --args "${comm
 
 deliverablesJSON='["hosted-pages"]'
 
-curl --silent --show-error --fail --location --request POST ${ECHOES_API_ENDPOINT} \
+response=$(curl --silent --show-error --fail --location --request POST ${ECHOES_API_ENDPOINT} \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer '"${API_KEY}"'' \
 --data-raw '{
@@ -29,5 +29,12 @@ curl --silent --show-error --fail --location --request POST ${ECHOES_API_ENDPOIN
     "deliverables": '"${deliverablesJSON}"',
     "commits": '"${commitsJSON}"',
     "url": "'"${url}"'"
+}')
+
+deploymentId=$(echo "${response}" | jq -r '.id')
+curl --silent --show-error --fail --location --request POST ${ECHOES_API_ENDPOINT}/${deploymentId}/status \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer '"${API_KEY}"'' \
+--data-raw '{
+    "status": "success"
 }'
-   

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -31,8 +31,9 @@ response=$(curl --silent --show-error --fail --location --request POST ${ECHOES_
     "url": "'"${url}"'"
 }')
 
-deploymentId=$(echo "${response}" | jq -r '.id')
-curl --silent --show-error --fail --location --request POST ${ECHOES_API_ENDPOINT}/${deploymentId}/status \
+ECHOESHQ_DEPLOYMENT_ID=$(echo "${response}" | jq -r '.id')
+echo ::set-output name=deployment_id::$(echo "${ECHOESHQ_DEPLOYMENT_ID}")
+curl --silent --show-error --fail --location --request POST ${ECHOES_API_ENDPOINT}/${ECHOESHQ_DEPLOYMENT_ID}/status \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer '"${API_KEY}"'' \
 --data-raw '{


### PR DESCRIPTION
updates the integration with echoeshq, includes a POST that includes a deployment status.

- [x] complete integration with a github action to tag a deployment as failure

Once we complete above then we can review and merge.