### PR TITLE
fix(custom-domain): preserve custom domain when starting session

### DIFF
--- a/src/components/StartHostedPathwaySessionFlow/StartHostedPathwaySessionFlow.tsx
+++ b/src/components/StartHostedPathwaySessionFlow/StartHostedPathwaySessionFlow.tsx
@@ -39,7 +39,8 @@ export const StartHostedCareflowSessionFlow: FC<
         },
       })
       const { sessionUrl } = data
-      window.location.href = sessionUrl
+      const url = new URL(sessionUrl)
+      window.location.href = `${window.location.href}/${url.pathname}`
     }
   }, [data, router])
 


### PR DESCRIPTION
Changes:
- when starting a pathway + session and using a custom domain, we want the redirect from the initial URL (e.g. www.company.com/c/1234asdf) to land on a session URL with the same domain name preserved (e.g. www.company.com/en?sessionId=zxcv5678). The BE should handle this ideally but we can make doubly sure for now by forcing the domain name to match that of the incoming link

