### PR TITLE
V1C-205 – fix(form): show a loader when form is being submitted

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.6",
-    "@awell-health/ui-library": "0.1.43",
+    "@awell-health/ui-library": "0.1.44",
     "@formsort/react-embed": "^3.1.1",
     "@localazy/cli": "^1.7.5",
     "@sentry/nextjs": "^7.59.3",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -42,6 +42,7 @@
       "next_question_label": "Weiter",
       "previous_question_label": "Vorheriger",
       "question_required_error": "Diese Frage ist erforderlich.",
+      "submitting": "Formular wird abgesendet...",
       "questions": {
         "select": {
           "no_options": "Keine Optionen gefunden",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -30,6 +30,7 @@
       "invalid_phone_number": "Phone number is invalid.",
       "form_has_errors": "Please fix the errors in the form before submitting",
       "saving_error": "Form submission failed.",
+      "submitting": "Submitting form...",
       "questions": {
         "yes_no": {
           "yes_answer": "Yes",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -42,6 +42,7 @@
       "next_question_label": "Siguiente",
       "previous_question_label": "Anterior",
       "question_required_error": "Esta pregunta es obligatoria.",
+      "submitting": "Enviando formulario...",
       "questions": {
         "select": {
           "no_options": "No se encontraron opciones",

--- a/public/locales/et/common.json
+++ b/public/locales/et/common.json
@@ -42,6 +42,7 @@
       "next_question_label": "Järgmine",
       "previous_question_label": "Eelmine",
       "question_required_error": "See küsimus on kohustuslik.",
+      "submitting": "Vormi esitamine...",
       "questions": {
         "select": {
           "no_options": "Valikuid ei leidnud",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -42,6 +42,7 @@
       "next_question_label": "Suivant",
       "previous_question_label": "Précédent",
       "question_required_error": "Cette question est obligatoire.",
+      "submitting": "Soumission du formulaire...",
       "questions": {
         "select": {
           "no_options": "Aucune option trouvée",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -42,6 +42,7 @@
       "next_question_label": "Volgende",
       "previous_question_label": "Vorige",
       "question_required_error": "Deze vraag is verplicht.",
+      "submitting": "Vragenlijst verzenden...",
       "questions": {
         "select": {
           "no_options": "No options found",

--- a/public/locales/ro/common.json
+++ b/public/locales/ro/common.json
@@ -42,6 +42,7 @@
       "next_question_label": "Mai departe",
       "previous_question_label": "Înapoi",
       "question_required_error": "Această întrebare este obligatorie.",
+      "submitting": "Se trimite formularul...",
       "questions": {
         "select": {
           "no_options": "Nu s-au găsit opțiuni",

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -42,6 +42,7 @@
       "next_question_label": "Следующий",
       "previous_question_label": "Предыдущий",
       "question_required_error": "Ответ на этот вопрос обязателен.",
+      "submitting": "Подача формы...",
       "questions": {
         "select": {
           "no_options": "Опции не найдены",

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -24,21 +24,24 @@ interface FormProps {
 }
 
 export const Form: FC<FormProps> = ({ activity }) => {
-  const { loading, form, error, refetch } = useForm(activity)
+  const { loading: isFetching, form, error, refetch } = useForm(activity)
   const { t } = useTranslation()
   const [evaluateFormRules] = useEvaluateFormRules(activity.object.id)
-  const { onSubmit } = useSubmitForm(activity)
+  const { onSubmit, isSubmitting } = useSubmitForm(activity)
   const { branding } = useHostedSession()
 
   const [formProgress, setFormProgress] = useLocalStorage(activity.id, '')
 
-  if (loading) {
+  if (isFetching) {
     return <LoadingPage title={t('activities.form.loading')} />
   }
   if (error || isNil(form)) {
     return (
       <ErrorPage title={t('activities.form.loading_error')} onRetry={refetch} />
     )
+  }
+  if (isSubmitting) {
+    return <LoadingPage title={t('activities.form.submitting')} />
   }
 
   const modifiedQuestions = form?.questions.map((question) => {

--- a/src/hooks/useSubmitForm/useSubmitForm.ts
+++ b/src/hooks/useSubmitForm/useSubmitForm.ts
@@ -6,7 +6,6 @@ import { useSubmitFormResponseMutation } from './types'
 import { captureException } from '@sentry/nextjs'
 import { useCurrentActivity } from '../../components/Activities'
 interface UseFormActivityHook {
-  disabled: boolean
   onSubmit: (response: Array<AnswerInput>) => Promise<void>
   isSubmitting: boolean
 }
@@ -51,7 +50,6 @@ export const useSubmitForm = (activity: Activity): UseFormActivityHook => {
 
   return {
     onSubmit,
-    disabled: isSubmitting,
     isSubmitting,
   }
 }

--- a/src/hooks/useSubmitForm/useSubmitForm.ts
+++ b/src/hooks/useSubmitForm/useSubmitForm.ts
@@ -8,6 +8,7 @@ import { useCurrentActivity } from '../../components/Activities'
 interface UseFormActivityHook {
   disabled: boolean
   onSubmit: (response: Array<AnswerInput>) => Promise<void>
+  isSubmitting: boolean
 }
 
 export const useSubmitForm = (activity: Activity): UseFormActivityHook => {
@@ -51,5 +52,6 @@ export const useSubmitForm = (activity: Activity): UseFormActivityHook => {
   return {
     onSubmit,
     disabled: isSubmitting,
+    isSubmitting,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,10 +84,10 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@awell-health/ui-library@0.1.42":
-  version "0.1.42"
-  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.42.tgz#1c948e0fac30ac2080d8b8c9444b333a4265bf3f"
-  integrity sha512-cI1P+tvxZCOMFtmRQqZdsZHKUZY8x+TlnZKQ6qPtph5TMyrCxu6EGsgj+y/sXuLYueAQSGnF/Xe/I8bGPPS77Q==
+"@awell-health/ui-library@0.1.43":
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.43.tgz#848eefc4073c63d947259cbf0672452e27144d75"
+  integrity sha512-IjUkaYttREDmPGZoMcBhlQcQ0InWV0CqkVjN8oCtwvuQOhWZrZ8ms9cccIYS+eV7ZA26zdJG5SMF1lGWWJ5w+Q==
   dependencies:
     "@calcom/embed-react" "^1.0.10"
     "@heroicons/react" "^2.0.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,10 +84,10 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@awell-health/ui-library@0.1.43":
-  version "0.1.43"
-  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.43.tgz#848eefc4073c63d947259cbf0672452e27144d75"
-  integrity sha512-IjUkaYttREDmPGZoMcBhlQcQ0InWV0CqkVjN8oCtwvuQOhWZrZ8ms9cccIYS+eV7ZA26zdJG5SMF1lGWWJ5w+Q==
+"@awell-health/ui-library@0.1.44":
+  version "0.1.44"
+  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.44.tgz#fa7fdc7ef7824473ef8d2c67a05f694a5d5c301c"
+  integrity sha512-Y5XPkNvNPKcGN2c1KyNAbHTb0013Hjt4CD2TTEC61pZ09hA3Nblm11VvYI/MUxd+XClrIYkXM3sMtv2m/F5PbQ==
   dependencies:
     "@calcom/embed-react" "^1.0.10"
     "@heroicons/react" "^2.0.13"


### PR DESCRIPTION
A form activity completion is dependent on 2 mutations:

1. Evaluate Form Rules
2. Submit Form Response

Only on success of both of these mutations, we mark the activity as completed.

The blinking of last question is because of the delay between `EvaluateFormRules` and `SubmitFormResponse`. See this example:
![2024-02-07 18 01 02](https://github.com/awell-health/hosted-pages/assets/23508720/be139b06-8790-4af5-b00a-07361ad406cf)

The last question was shown just after completion of `EvaluateFormRules` mutation.


----


After adding another loader for 'Submitting Form' process, here's the result:

![2024-02-07 18 08 38](https://github.com/awell-health/hosted-pages/assets/23508720/9b9b9a95-bcf9-4217-b119-aead5dcafa17)

Instead of showing the last question again, we showed the 'Submitting form...' loader text