### PR TITLE
V1C-398 support for passing in patient identifier in hosted pages links

### DIFF
--- a/pages/api/startHostedPathwaySessionFromLink/[hostedPagesLinkId].ts
+++ b/pages/api/startHostedPathwaySessionFromLink/[hostedPagesLinkId].ts
@@ -58,7 +58,7 @@ export default async function handler(
           id: hostedPagesLinkId,
           ...(isNil(identifier) || identifier === 'undefined'
             ? {}
-            : { careflow_patient_identifier: identifier }),
+            : { careflow_patient_identifier: decodeURIComponent(identifier) }),
         },
       },
     }),

--- a/pages/api/startHostedPathwaySessionFromLink/[hostedPagesLinkId].ts
+++ b/pages/api/startHostedPathwaySessionFromLink/[hostedPagesLinkId].ts
@@ -6,7 +6,7 @@ import { isNil } from 'lodash'
 
 export type StartHostedCareflowSessionParams = {
   hostedPagesLinkId: string
-  identifier?: string
+  patientIdentifier?: string
 }
 
 export type StartHostedCareflowSessionPayload = {
@@ -24,7 +24,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Data>
 ) {
-  const { hostedPagesLinkId, identifier } =
+  const { hostedPagesLinkId, patientIdentifier } =
     req.query as StartHostedCareflowSessionParams
 
   const token = jwt.sign(
@@ -56,9 +56,11 @@ export default async function handler(
       variables: {
         input: {
           id: hostedPagesLinkId,
-          ...(isNil(identifier) || identifier === 'undefined'
+          ...(isNil(patientIdentifier) || patientIdentifier === 'undefined'
             ? {}
-            : { careflow_patient_identifier: decodeURIComponent(identifier) }),
+            : {
+                patient_identifier: decodeURIComponent(patientIdentifier),
+              }),
         },
       },
     }),

--- a/pages/api/startHostedPathwaySessionFromLink/[hostedPagesLinkId].ts
+++ b/pages/api/startHostedPathwaySessionFromLink/[hostedPagesLinkId].ts
@@ -6,6 +6,7 @@ import { isNil } from 'lodash'
 
 export type StartHostedCareflowSessionParams = {
   hostedPagesLinkId: string
+  identifier?: string
 }
 
 export type StartHostedCareflowSessionPayload = {
@@ -23,7 +24,8 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Data>
 ) {
-  const { hostedPagesLinkId } = req.query as StartHostedCareflowSessionParams
+  const { hostedPagesLinkId, identifier } =
+    req.query as StartHostedCareflowSessionParams
 
   const token = jwt.sign(
     {
@@ -54,6 +56,9 @@ export default async function handler(
       variables: {
         input: {
           id: hostedPagesLinkId,
+          ...(isNil(identifier) || identifier === 'undefined'
+            ? {}
+            : { careflow_patient_identifier: identifier }),
         },
       },
     }),

--- a/pages/c/[hostedPagesLinkId].tsx
+++ b/pages/c/[hostedPagesLinkId].tsx
@@ -8,17 +8,21 @@ import { StartHostedCareflowSessionParams } from '../api/startHostedPathwaySessi
 import { StartHostedCareflowSessionFlow } from '../../src/components/StartHostedPathwaySessionFlow'
 
 /**
- * Purpose of this page is to support shortened URLs i.e. 'hosted-pages.awellhealth.com/c/<hostedCareflowLinkId>'
+ * Purpose of this page is to support shortened URLs i.e. 'goto.awell.health/c/<hostedCareflowLinkId>?identifier=system|id'
  */
 const HostedCareflowLink: NextPage = () => {
   const router = useRouter()
 
-  const { hostedPagesLinkId } = router.query as StartHostedCareflowSessionParams
+  const { hostedPagesLinkId, identifier } =
+    router.query as StartHostedCareflowSessionParams
 
   return (
     <NoSSRComponent>
       <ThemeProvider accentColor={AWELL_BRAND_COLOR}>
-        <StartHostedCareflowSessionFlow hostedPagesLinkId={hostedPagesLinkId} />
+        <StartHostedCareflowSessionFlow
+          hostedPagesLinkId={hostedPagesLinkId}
+          identifier={identifier}
+        />
       </ThemeProvider>
     </NoSSRComponent>
   )

--- a/pages/c/[hostedPagesLinkId].tsx
+++ b/pages/c/[hostedPagesLinkId].tsx
@@ -8,12 +8,12 @@ import { StartHostedCareflowSessionParams } from '../api/startHostedPathwaySessi
 import { StartHostedCareflowSessionFlow } from '../../src/components/StartHostedPathwaySessionFlow'
 
 /**
- * Purpose of this page is to support shortened URLs i.e. 'goto.awell.health/c/<hostedCareflowLinkId>?identifier=system|id'
+ * Purpose of this page is to support shortened URLs i.e. 'goto.awell.health/c/<hostedCareflowLinkId>?patientIdentifier=system|id'
  */
 const HostedCareflowLink: NextPage = () => {
   const router = useRouter()
 
-  const { hostedPagesLinkId, identifier } =
+  const { hostedPagesLinkId, patientIdentifier } =
     router.query as StartHostedCareflowSessionParams
 
   return (
@@ -21,7 +21,7 @@ const HostedCareflowLink: NextPage = () => {
       <ThemeProvider accentColor={AWELL_BRAND_COLOR}>
         <StartHostedCareflowSessionFlow
           hostedPagesLinkId={hostedPagesLinkId}
-          identifier={identifier}
+          patientIdentifier={patientIdentifier}
         />
       </ThemeProvider>
     </NoSSRComponent>

--- a/src/components/StartHostedPathwaySessionFlow/StartHostedPathwaySessionFlow.tsx
+++ b/src/components/StartHostedPathwaySessionFlow/StartHostedPathwaySessionFlow.tsx
@@ -19,12 +19,14 @@ type StartHostedCareflowSessionFlowProps = StartHostedCareflowSessionParams
 
 export const StartHostedCareflowSessionFlow: FC<
   StartHostedCareflowSessionFlowProps
-> = ({ hostedPagesLinkId }): JSX.Element => {
+> = ({ hostedPagesLinkId, identifier }): JSX.Element => {
   const router = useRouter()
   const { t } = useTranslation()
 
   const { data } = useSWR<StartHostedCareflowSessionPayload>(
-    `/api/startHostedPathwaySessionFromLink/${hostedPagesLinkId}`,
+    `/api/startHostedPathwaySessionFromLink/${hostedPagesLinkId}${
+      isNil(identifier) ? '' : `?identifier=${identifier}`
+    }`,
     fetcher
   )
 

--- a/src/components/StartHostedPathwaySessionFlow/StartHostedPathwaySessionFlow.tsx
+++ b/src/components/StartHostedPathwaySessionFlow/StartHostedPathwaySessionFlow.tsx
@@ -19,13 +19,13 @@ type StartHostedCareflowSessionFlowProps = StartHostedCareflowSessionParams
 
 export const StartHostedCareflowSessionFlow: FC<
   StartHostedCareflowSessionFlowProps
-> = ({ hostedPagesLinkId, identifier }): JSX.Element => {
+> = ({ hostedPagesLinkId, patientIdentifier }): JSX.Element => {
   const router = useRouter()
   const { t } = useTranslation()
 
   const { data } = useSWR<StartHostedCareflowSessionPayload>(
     `/api/startHostedPathwaySessionFromLink/${hostedPagesLinkId}${
-      isNil(identifier) ? '' : `?identifier=${identifier}`
+      isNil(patientIdentifier) ? '' : `?patientIdentifier=${patientIdentifier}`
     }`,
     fetcher
   )


### PR DESCRIPTION
Backwards compatible -> ignores query params if not provided

related to V1C-398