### PR TITLE
refactor: simplify how to get/parse custom theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.6",
-    "@awell-health/ui-library": "0.1.49",
+    "@awell-health/ui-library": "0.1.50",
     "@formsort/react-embed": "^3.1.1",
     "@localazy/cli": "^1.7.5",
     "@sentry/nextjs": "^7.59.3",

--- a/src/hooks/useHostedSession/branding/customTheme.test.ts
+++ b/src/hooks/useHostedSession/branding/customTheme.test.ts
@@ -1,9 +1,9 @@
-import { CustomThemeApiField } from './validation.zod'
+import { getTheme } from './customTheme'
 
 describe('Custom theme branding', () => {
   test('When custom theme is empty string, the default theme is set', () => {
     const customTheme = ''
-    const outcome = CustomThemeApiField.parse(customTheme)
+    const outcome = getTheme(customTheme)
 
     expect(outcome).toStrictEqual({
       layout: { showCloseButton: true, showLogo: true },
@@ -20,7 +20,7 @@ describe('Custom theme branding', () => {
 
   test('When custom theme is empty object, the default theme is set', () => {
     const customTheme = '{}'
-    const outcome = CustomThemeApiField.parse(customTheme)
+    const outcome = getTheme(customTheme)
 
     expect(outcome).toStrictEqual({
       layout: { showCloseButton: true, showLogo: true },
@@ -37,7 +37,7 @@ describe('Custom theme branding', () => {
 
   test('When custom theme is invalid JSON string, the default theme is set', () => {
     const customTheme = 'no valid json'
-    const outcome = CustomThemeApiField.parse(customTheme)
+    const outcome = getTheme(customTheme)
 
     expect(outcome).toStrictEqual({
       layout: { showCloseButton: true, showLogo: true },
@@ -53,8 +53,24 @@ describe('Custom theme branding', () => {
   })
 
   test('When custom theme is undefined, the default theme is set', () => {
-    const customTheme = undefined
-    const outcome = CustomThemeApiField.parse(customTheme)
+    const outcome = getTheme()
+
+    expect(outcome).toStrictEqual({
+      layout: { showCloseButton: true, showLogo: true },
+      form: {
+        showAsterisksForRequiredQuestions: true,
+      },
+      locales: {
+        form: {
+          cta_submit: '',
+        },
+      },
+    })
+  })
+
+  test('When custom theme is null, the default theme is set', () => {
+    const customTheme = null
+    const outcome = getTheme(customTheme)
 
     expect(outcome).toStrictEqual({
       layout: { showCloseButton: true, showLogo: true },
@@ -77,7 +93,7 @@ describe('Custom theme branding', () => {
         showCloseButton: false,
       },
     })
-    const outcome = CustomThemeApiField.parse(customTheme)
+    const outcome = getTheme(customTheme)
 
     expect(outcome).toStrictEqual({
       layout: { showCloseButton: false, showLogo: true },
@@ -107,7 +123,7 @@ describe('Custom theme branding', () => {
         },
       },
     })
-    const outcome = CustomThemeApiField.parse(customTheme)
+    const outcome = getTheme(customTheme)
 
     expect(outcome).toStrictEqual({
       layout: { showCloseButton: false, showLogo: false },
@@ -128,7 +144,7 @@ describe('Custom theme branding', () => {
         showLogo: false,
       },
     })
-    const outcome = CustomThemeApiField.parse(customTheme)
+    const outcome = getTheme(customTheme)
 
     expect(outcome).toStrictEqual({
       layout: { showCloseButton: true, showLogo: false },

--- a/src/hooks/useHostedSession/branding/customTheme.ts
+++ b/src/hooks/useHostedSession/branding/customTheme.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { Maybe } from '../../../types'
 import { stringToJSONSchema } from './stringToJson'
 
 const DEFAULTS = {
@@ -47,6 +48,11 @@ const CustomThemeFields = z
   })
   .default({})
 
-export const CustomThemeApiField = stringToJSONSchema.pipe(CustomThemeFields)
+const CustomThemeSchema = stringToJSONSchema.pipe(CustomThemeFields)
 
-export type CustomThemeFieldsType = z.infer<typeof CustomThemeApiField>
+export type CustomTheme = z.infer<typeof CustomThemeSchema>
+
+export const getTheme = (customThemeJsonStr?: Maybe<string>): CustomTheme => {
+  const customTheme = customThemeJsonStr ?? ''
+  return CustomThemeSchema.parse(customTheme)
+}

--- a/src/hooks/useHostedSession/branding/index.ts
+++ b/src/hooks/useHostedSession/branding/index.ts
@@ -1,0 +1,1 @@
+export * from './customTheme'

--- a/src/hooks/useHostedSession/useHostedSession.ts
+++ b/src/hooks/useHostedSession/useHostedSession.ts
@@ -16,16 +16,13 @@ import { updateQuery } from '../../services/graphql'
 import * as Sentry from '@sentry/nextjs'
 import { useRouter } from 'next/router'
 import { Maybe } from '../../types'
-import {
-  CustomThemeApiField,
-  CustomThemeFieldsType,
-} from './branding/validation.zod'
+import { type CustomTheme, getTheme } from './branding'
 
 interface UseHostedSessionHook {
   loading: boolean
   session?: HostedSession
   branding?: Maybe<BrandingSettings>
-  theme: CustomThemeFieldsType
+  theme: CustomTheme
   error?: string
   refetch?: () => {}
 }
@@ -33,8 +30,7 @@ interface UseHostedSessionHook {
 const POLLING_DELAY_MS = 2000
 
 export const useHostedSession = (): UseHostedSessionHook => {
-  const defaultTheme = CustomThemeApiField.parse(JSON.stringify({}))
-  console.log({ defaultTheme })
+  const defaultTheme = getTheme()
   const { data, loading, error, refetch } = useGetHostedSessionQuery({
     pollInterval: POLLING_DELAY_MS,
     onError: (error) => {
@@ -134,9 +130,7 @@ export const useHostedSession = (): UseHostedSessionHook => {
     loading: false,
     session: data?.hostedSession?.session,
     branding: data?.hostedSession?.branding,
-    theme: CustomThemeApiField.parse(
-      data?.hostedSession?.branding?.custom_theme ?? JSON.stringify({})
-    ),
+    theme: getTheme(data?.hostedSession?.branding?.custom_theme),
     refetch,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,10 +84,10 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@awell-health/ui-library@0.1.49":
-  version "0.1.49"
-  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.49.tgz#1defd104d39029cd13dfdda565aa10fc92958da2"
-  integrity sha512-4Ynf5bQw1f6WMYWByyCs6YszhkdmCaQlXjayKE0ayy2v9UwfBw4lmch3w8O6md/aAzoX94ZpZZbGCl+bGCWRVA==
+"@awell-health/ui-library@0.1.50":
+  version "0.1.50"
+  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.50.tgz#01c431a9cba723bf37a4d101395e41e4aa0a02f0"
+  integrity sha512-K+nh5Em1gNILLG9Ub+cS8V1rWqL94J1XE/SiMbps8OayN5P8JCFeO3uLPRnhUeKbF22bYGpMoDUrh5lYVKTheA==
   dependencies:
     "@calcom/embed-react" "^1.0.10"
     "@heroicons/react" "^2.0.13"


### PR DESCRIPTION
- exposes only getTheme function and CustomTheme type to outside world
- allows to pass in null/undefined to getTheme function
- adds tests for passing null to getTheme
- bumps ui-library version latest one with deep link support in message