### PR TITLE
fix: render session flow only when router isReady, no re-render

### DIFF
--- a/pages/c/[hostedPagesLinkId].tsx
+++ b/pages/c/[hostedPagesLinkId].tsx
@@ -6,23 +6,27 @@ import { AWELL_BRAND_COLOR } from '../../src/config'
 import { NoSSRComponent } from '../../src/components/NoSSR'
 import { StartHostedCareflowSessionParams } from '../api/startHostedPathwaySessionFromLink/[hostedPagesLinkId]'
 import { StartHostedCareflowSessionFlow } from '../../src/components/StartHostedPathwaySessionFlow'
+import { LoadingPage } from '../../src/components'
 
 /**
  * Purpose of this page is to support shortened URLs i.e. 'goto.awell.health/c/<hostedCareflowLinkId>?patient_identifier=system|id'
  */
 const HostedCareflowLink: NextPage = () => {
-  const router = useRouter()
+  const { query, isReady } = useRouter()
 
   const { hostedPagesLinkId, patient_identifier } =
-    router.query as StartHostedCareflowSessionParams
+    query as StartHostedCareflowSessionParams
 
   return (
     <NoSSRComponent>
       <ThemeProvider accentColor={AWELL_BRAND_COLOR}>
-        <StartHostedCareflowSessionFlow
-          hostedPagesLinkId={hostedPagesLinkId}
-          patient_identifier={patient_identifier}
-        />
+        {isReady && (
+          <StartHostedCareflowSessionFlow
+            hostedPagesLinkId={hostedPagesLinkId}
+            patient_identifier={patient_identifier}
+          />
+        )}
+        {!isReady && <LoadingPage showLogoBox />}
       </ThemeProvider>
     </NoSSRComponent>
   )

--- a/src/components/StartHostedPathwaySessionFlow/StartHostedPathwaySessionFlow.tsx
+++ b/src/components/StartHostedPathwaySessionFlow/StartHostedPathwaySessionFlow.tsx
@@ -1,5 +1,4 @@
 import { isNil } from 'lodash'
-import { useRouter } from 'next/router'
 import { FC, useEffect } from 'react'
 import useSWR from 'swr'
 import { ErrorPage } from '../ErrorPage'
@@ -19,17 +18,13 @@ type StartHostedCareflowSessionFlowProps = StartHostedCareflowSessionParams
 export const StartHostedCareflowSessionFlow: FC<
   StartHostedCareflowSessionFlowProps
 > = ({ hostedPagesLinkId, patient_identifier }): JSX.Element => {
-  const router = useRouter()
   const { t } = useTranslation()
-
-  const { data } = useSWR<StartHostedCareflowSessionPayload>(
-    `/api/startHostedPathwaySessionFromLink/${hostedPagesLinkId}${
-      isNil(patient_identifier)
-        ? ''
-        : `?patient_identifier=${patient_identifier}`
-    }`,
-    fetcher
-  )
+  const startSessionUrl = `/api/startHostedPathwaySessionFromLink/${hostedPagesLinkId}`
+  const queryParams = isNil(patient_identifier)
+    ? ''
+    : `?patient_identifier=${patient_identifier}`
+  const key = `${startSessionUrl}${queryParams}`
+  const { data } = useSWR<StartHostedCareflowSessionPayload>(key, fetcher)
 
   useEffect(() => {
     if (!isNil(data) && !isNil(data?.sessionUrl)) {
@@ -44,7 +39,7 @@ export const StartHostedCareflowSessionFlow: FC<
       const { sessionUrl } = data
       window.location.href = sessionUrl
     }
-  }, [data, router])
+  }, [data])
 
   if (data?.error) {
     addSentryBreadcrumb({


### PR DESCRIPTION
Because now there is no re-render, we don't start 2 careflows V1C-422