### PR TITLE
Tp 1336 fix repeating activities

### DIFF
--- a/src/components/Activities/Activities.tsx
+++ b/src/components/Activities/Activities.tsx
@@ -1,28 +1,17 @@
-/* eslint-disable react-hooks/exhaustive-deps */
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useEffect } from 'react'
 import { useCurrentActivity } from './hooks'
 import { LoadingPage } from '../LoadingPage'
-import { useTranslation } from 'next-i18next'
 import { ActivityFactory } from './ActivityFactory'
 
 // session will already expire after 15 seconds
-const TIMEOUT_DELAY = 10000
 const RELOAD_DELAY = 20000
 
 export const Activities: FC = () => {
   const { currentActivity, waitingForNewActivities } = useCurrentActivity()
-  const { t } = useTranslation()
-  const initialMessage = t('activities.waiting_for_new_activities')
-  const unexpectedMessage = t('activities.waiting_unexpected')
-  const [message, setMessage] = useState<string>(initialMessage)
 
   useEffect(() => {
-    let timeoutTimer: NodeJS.Timeout
     let reloadTimer: NodeJS.Timeout
     if (waitingForNewActivities) {
-      timeoutTimer = setTimeout(() => {
-        setMessage(unexpectedMessage)
-      }, TIMEOUT_DELAY)
       reloadTimer = setTimeout(() => {
         window.location.reload()
       }, RELOAD_DELAY)
@@ -30,9 +19,6 @@ export const Activities: FC = () => {
 
     // clear interval on component unmount
     return () => {
-      if (timeoutTimer) {
-        clearTimeout(timeoutTimer)
-      }
       if (reloadTimer) {
         clearTimeout(reloadTimer)
       }

--- a/src/components/Activities/context/ActivityContext.ts
+++ b/src/components/Activities/context/ActivityContext.ts
@@ -4,13 +4,11 @@ import { Activity } from '../types'
 export interface ActivityContextInterface {
   currentActivity: Activity | undefined
   waitingForNewActivities: boolean
-  unsetCurrentActivity: () => void
 }
 
 const initialContext: ActivityContextInterface = {
   currentActivity: undefined,
   waitingForNewActivities: true,
-  unsetCurrentActivity: () => {},
 }
 
 export const ActivityContext =

--- a/src/components/Activities/context/ActivityProvider.tsx
+++ b/src/components/Activities/context/ActivityProvider.tsx
@@ -48,6 +48,9 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
     }
   }
 
+  // activities list changes as we get new activities from the server or as we complete activities
+  // this useEffect drives whole AHP logic, only by activities being changed in apollo cache
+  // and base on their status do we determine what to show to the user
   useEffect(() => {
     onActivitiesChange()
   }, [activities])

--- a/src/components/Activities/context/ActivityProvider.tsx
+++ b/src/components/Activities/context/ActivityProvider.tsx
@@ -36,14 +36,13 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
       const firstActive = activities.find(isActive)
       if (isNil(firstActive)) {
         // nothing to activate, start polling for new activities so we don't rely on subscriptions
+        setCurrentActivity(undefined)
         startPolling(POLLING_DELAY)
       } else {
         // we have something to activate, stop polling, no need for it
+        setCurrentActivity(firstActive)
         stopPolling()
       }
-      // set to the first active activity or undefined if none found,
-      // undefined will result in loading page with reload timer
-      setCurrentActivity(firstActive)
     }
   }, [activities])
 

--- a/src/components/Activities/context/ActivityProvider.tsx
+++ b/src/components/Activities/context/ActivityProvider.tsx
@@ -37,17 +37,11 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
     }
   }
 
-  const unsetCurrentActivity = () => {
-    setCurrentActivity(undefined)
-  }
 
   useEffect(() => {
     handleSetCurrent()
   }, [activities])
 
-  useEffect(() => {
-    handleSetCurrent()
-  }, [currentActivity])
 
   if (loading) {
     return <LoadingPage />
@@ -62,11 +56,7 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
 
   return (
     <ActivityContext.Provider
-      value={{
-        currentActivity,
-        unsetCurrentActivity,
-        waitingForNewActivities,
-      }}
+      value={{ currentActivity, waitingForNewActivities }}
     >
       {children}
     </ActivityContext.Provider>

--- a/src/components/Activities/context/ActivityProvider.tsx
+++ b/src/components/Activities/context/ActivityProvider.tsx
@@ -12,6 +12,9 @@ const POLLING_DELAY = 5000 // 5 seconds
 interface ActivityProviderProps {
   children?: React.ReactNode
 }
+
+const isActive = (activity: Activity | undefined) =>
+  activity?.status === ActivityStatus.Active
 /**
  * Provider to store of the current activity being shown to user
  * and to determine the next activity from the activities list.
@@ -22,19 +25,15 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
   const { activities, loading, error, refetch, startPolling, stopPolling } =
     useSessionActivities()
 
-  // determine if we have current activity set and does it have active status
-  // if so, we a waiting for stakeholder to complete the activity
-  const isCurrentActive = () => {
+  // activities list changes as we get new activities from the server or as we complete activities
+  // this useEffect drives whole AHP logic, only by activities being changed in apollo cache
+  // and base on their status do we determine what to show to the user
+  useEffect(() => {
+    // get current from the list, it may be updated
     const current = activities.find(({ id }) => id === currentActivity?.id)
-    return !isNil(current) && current.status === ActivityStatus.Active
-  }
-
-  const onActivitiesChange = () => {
-    // we don't have current activity or current is no longer active
-    if (!isCurrentActive()) {
-      const firstActive = activities.find(
-        ({ status }) => status === ActivityStatus.Active
-      )
+    // try and change current activity if it's not active
+    if (!isActive(current)) {
+      const firstActive = activities.find(isActive)
       if (isNil(firstActive)) {
         // nothing to activate, start polling for new activities so we don't rely on subscriptions
         startPolling(POLLING_DELAY)
@@ -46,13 +45,6 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
       // undefined will result in loading page with reload timer
       setCurrentActivity(firstActive)
     }
-  }
-
-  // activities list changes as we get new activities from the server or as we complete activities
-  // this useEffect drives whole AHP logic, only by activities being changed in apollo cache
-  // and base on their status do we determine what to show to the user
-  useEffect(() => {
-    onActivitiesChange()
   }, [activities])
 
   if (loading) {

--- a/src/hooks/useCompleteExtensionActivity/useCompleteExtensionActivity.ts
+++ b/src/hooks/useCompleteExtensionActivity/useCompleteExtensionActivity.ts
@@ -2,7 +2,6 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'next-i18next'
 import { toast } from 'react-toastify'
 import { captureException } from '@sentry/nextjs'
-import { useCurrentActivity } from '../../components/Activities'
 import { type DataPoints, useCompleteExtensionActivityMutation } from './types'
 
 interface UseCompleteExtensionActivityHook {
@@ -15,7 +14,6 @@ export const useCompleteExtensionActivity =
     const { t } = useTranslation()
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [completeExtensionActivity] = useCompleteExtensionActivityMutation()
-    const { unsetCurrentActivity } = useCurrentActivity()
 
     const onSubmit: UseCompleteExtensionActivityHook['onSubmit'] = useCallback(
       async (activity_id, data_points) => {
@@ -28,7 +26,6 @@ export const useCompleteExtensionActivity =
         }
         try {
           await completeExtensionActivity({ variables })
-          unsetCurrentActivity()
         } catch (error) {
           toast.error(t('activities.checklist.saving_error'))
           captureException(error, {

--- a/src/hooks/useMessage/useMessage.ts
+++ b/src/hooks/useMessage/useMessage.ts
@@ -4,7 +4,6 @@ import type { Activity, Message } from './types'
 import { useGetMessageQuery, useMarkMessageAsReadMutation } from './types'
 import { captureException } from '@sentry/nextjs'
 import { GraphQLError } from 'graphql'
-import { useCurrentActivity } from '../../components/Activities'
 interface UseMessageActivityHook {
   loading: boolean
   message?: Message
@@ -20,7 +19,6 @@ export const useMessage = (activity: Activity): UseMessageActivityHook => {
     object: { id: message_id },
   } = activity
   const [markMessageAsRead] = useMarkMessageAsReadMutation()
-  const { unsetCurrentActivity } = useCurrentActivity()
 
   const variables = { id: message_id }
   const { data, loading, error, refetch } = useGetMessageQuery({
@@ -52,7 +50,6 @@ export const useMessage = (activity: Activity): UseMessageActivityHook => {
     }
     try {
       await markMessageAsRead({ variables: markMessageAsReadVariables })
-      unsetCurrentActivity()
     } catch (err) {
       toast.error(t('activities.message.toast_mark_as_read_error'))
       captureException(err, {

--- a/src/hooks/useSubmitChecklist/useSubmitChecklist.ts
+++ b/src/hooks/useSubmitChecklist/useSubmitChecklist.ts
@@ -4,7 +4,6 @@ import { useTranslation } from 'next-i18next'
 import type { Activity } from './types'
 import { useSubmitChecklistMutation } from './types'
 import { captureException } from '@sentry/nextjs'
-import { useCurrentActivity } from '../../components/Activities'
 
 interface UseChecklistHook {
   onSubmit: () => Promise<void>
@@ -15,7 +14,6 @@ export const useSubmitChecklist = (activity: Activity): UseChecklistHook => {
   const { t } = useTranslation()
   const { id: activity_id } = activity
   const [submitChecklist] = useSubmitChecklistMutation()
-  const { unsetCurrentActivity } = useCurrentActivity()
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const onSubmit = async () => {
@@ -27,7 +25,6 @@ export const useSubmitChecklist = (activity: Activity): UseChecklistHook => {
     }
     try {
       await submitChecklist({ variables })
-      unsetCurrentActivity()
     } catch (error) {
       setIsSubmitting(false)
       toast.error(t('activities.checklist.saving_error'))

--- a/src/hooks/useSubmitForm/useSubmitForm.ts
+++ b/src/hooks/useSubmitForm/useSubmitForm.ts
@@ -4,7 +4,6 @@ import { useTranslation } from 'next-i18next'
 import type { Activity, AnswerInput } from './types'
 import { useSubmitFormResponseMutation } from './types'
 import { captureException } from '@sentry/nextjs'
-import { useCurrentActivity } from '../../components/Activities'
 interface UseFormActivityHook {
   onSubmit: (response: Array<AnswerInput>) => Promise<void>
   isSubmitting: boolean
@@ -13,7 +12,6 @@ interface UseFormActivityHook {
 export const useSubmitForm = (activity: Activity): UseFormActivityHook => {
   const { t } = useTranslation()
   const { id: activity_id } = activity
-  const { unsetCurrentActivity } = useCurrentActivity()
 
   const [submitFormResponse] = useSubmitFormResponseMutation()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -29,7 +27,6 @@ export const useSubmitForm = (activity: Activity): UseFormActivityHook => {
 
     try {
       await submitFormResponse({ variables })
-      unsetCurrentActivity()
     } catch (error) {
       setIsSubmitting(false)
       toast.error(t('activities.form.saving_error'))


### PR DESCRIPTION
Very hard to reproduce the issue. 
After playing with manually unsetting current activity I've managed to do it. Looks like there is a race condition between state update via cache and manual one.

As if when we did manual update we were not working with up to date activities array, which cause us to select same activity again.

With this PR determining what should current activity be is now driven solely by cache update, and activity can change only when actual status in activity array changes.

In addition to this polling for activities is no done on demand, only when we have no current activity. I've tested this with subscription disabled and it works fine.

Also I did a cleanup of timer we no longer need.

https://www.loom.com/share/8d479878a21044f6b65aa4f7046e2263?sid=f361fa77-c530-4ae3-b6cc-6206308ee2c9
