### PR TITLE
fix: use di to initialise the logger instance

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,11 @@ const { i18n } = require('./next-i18next.config')
 const withImages = require('next-images')
 const withPlugins = require('next-compose-plugins')
 const { withSentryConfig } = require('@sentry/nextjs')
+const { Logging } = require('@google-cloud/logging')
+const typedi = require('typedi')
+const path = require('path')
+const fs = require('fs')
+const os = require('os')
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -20,4 +25,23 @@ const nextPlugins = [
   (nextConfig) => withSentryConfig(nextConfig, sentryWebpackPluginOptions),
 ]
 
-module.exports = withPlugins(nextPlugins, nextConfig)
+const initialiseLogger = () => {
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS_KEY) {
+    const keyFile = path.join(os.tmpdir(), 'logging-sa-key.json')
+    fs.writeFileSync(
+      keyFile,
+      process.env.GOOGLE_APPLICATION_CREDENTIALS_KEY ?? ''
+    )
+    const gcpLoggingClient = new Logging({ keyFile })
+    const logger = gcpLoggingClient.log('hosted-sessions')
+    typedi.Container.set({ id: 'gcpLogger', value: logger })
+  }
+}
+
+module.exports = async (phase) => {
+  const config = withPlugins(nextPlugins, nextConfig)(phase, {})
+  if (['phase-production-server', 'phase-development-server'].includes(phase)) {
+    initialiseLogger()
+  }
+  return config
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-toastify": "^9.0.8",
     "stripe": "^15.5.0",
     "swr": "^1.3.0",
+    "typedi": "0.8.0",
     "use-local-storage": "^2.3.6",
     "zod": "^3.21.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8119,6 +8119,11 @@ type-fest@^0.7.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
+typedi@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/typedi/-/typedi-0.8.0.tgz#d8e203bd1d41a96e2b0a5c6295147d74b2b2d03e"
+  integrity sha512-/c7Bxnm6eh5kXx2I+mTuO+2OvoWni5+rXA3PhXwVWCtJRYmz3hMok5s1AKLzoDvNAZqj/Q/acGstN0ri5aQoOA==
+
 typescript@4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"


### PR DESCRIPTION
- reuse a known pattern with typedi container holding a logger
instance configured at startup time