### PR TITLE
TP-2035: prevent cleaning up of local storage in case of error

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -110,9 +110,9 @@ export const Form: FC<FormProps> = ({ activity }) => {
       },
     })
 
-    const result = await onSubmit(response)
+    const isSubmitted = await onSubmit(response)
 
-    if (result) {
+    if (isSubmitted) {
       setFormProgress(undefined)
     }
   }

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -109,8 +109,12 @@ export const Form: FC<FormProps> = ({ activity }) => {
         response: masker(response),
       },
     })
-    setFormProgress(undefined)
-    await onSubmit(response)
+
+    const result = await onSubmit(response)
+
+    if (result) {
+      setFormProgress(undefined)
+    }
   }
 
   const handleOnAnswersChange = (response: string): void => {


### PR DESCRIPTION
### Before (Form values get vanished as soon as there's an error in the Hosted Pages):

![2024-07-01 19 11 39](https://github.com/awell-health/hosted-pages/assets/23508720/f4f27353-0102-4743-b0de-56ea1dfd0501)

---

### After:
![2024-07-01 19 24 14](https://github.com/awell-health/hosted-pages/assets/23508720/161a5cf5-54dd-4b3f-b6d3-ad345d2e1cf0)

