### PR TITLE
ET-128: stop polling when session is complete + change error message

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -181,7 +181,14 @@ const Home: NextPageWithLayout = () => {
         >
           {renderSessionContent()}
           {error && (
-            <ErrorPage title={t('session.loading_error')} onRetry={refetch} />
+            <ErrorPage
+              title={
+                error === 'UNAUTHORIZED'
+                  ? t('session.session_completed_or_expired')
+                  : t('session.loading_error')
+              }
+              onRetry={refetch}
+            />
           )}
           <ToastContainer
             position="bottom-right"

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -107,6 +107,7 @@
     "loading_error": "Something went wrong while loading your session.",
     "redirecting_to_next_page": "Redirecting you in a moment...",
     "session_canceled": "Your session has been cancelled.",
-    "try_again": "Try again"
+    "try_again": "Try again",
+    "session_completed_or_expired": "Your session has been completed or expired."
   }
 }

--- a/src/hooks/useHostedSession/useHostedSession.ts
+++ b/src/hooks/useHostedSession/useHostedSession.ts
@@ -113,6 +113,13 @@ export const useHostedSession = (): UseHostedSessionHook => {
         hostedSession,
         branding: data?.hostedSession.branding,
       })
+
+      if (
+        hostedSession.status === HostedSessionStatus.Completed ||
+        hostedSession.status === HostedSessionStatus.Expired
+      ) {
+        setIsSessionCompleted(true)
+      }
     }
   }, [data])
 

--- a/src/hooks/useHostedSession/useHostedSession.ts
+++ b/src/hooks/useHostedSession/useHostedSession.ts
@@ -115,8 +115,9 @@ export const useHostedSession = (): UseHostedSessionHook => {
       })
 
       if (
-        hostedSession.status === HostedSessionStatus.Completed ||
-        hostedSession.status === HostedSessionStatus.Expired
+        !isNil(hostedSession?.status) &&
+        (hostedSession.status === HostedSessionStatus.Completed ||
+          hostedSession.status === HostedSessionStatus.Expired)
       ) {
         setIsSessionCompleted(true)
       }

--- a/src/hooks/useHostedSession/useHostedSession.ts
+++ b/src/hooks/useHostedSession/useHostedSession.ts
@@ -115,7 +115,7 @@ export const useHostedSession = (): UseHostedSessionHook => {
       })
 
       if (
-        !isNil(hostedSession?.status) &&
+        hostedSession &&
         (hostedSession.status === HostedSessionStatus.Completed ||
           hostedSession.status === HostedSessionStatus.Expired)
       ) {

--- a/src/hooks/useHostedSession/useHostedSession.ts
+++ b/src/hooks/useHostedSession/useHostedSession.ts
@@ -139,10 +139,7 @@ export const useHostedSession = (): UseHostedSessionHook => {
       (err) => err.extensions?.code === 'UNAUTHORIZED'
     )
 
-    const message = unauthorizedError
-      ? // TODO: update this message with translation
-        'Session has already been completed or expired.'
-      : error.message
+    const message = unauthorizedError ? 'UNAUTHORIZED' : error.message
 
     return {
       loading: false,


### PR DESCRIPTION
See this ticket for context: https://linear.app/awell/issue/ET-128/error-message-displayed-after-flow-completion-in-ahp-sessions

---

Summary:

- The `useHostedSession` hook uses `GetHostedSession` graphql query to fetch latest status of the hosted session.
- The query is fetched with a poll interval of 2 seconds.
- The query fails after the hosted session is completed because the access to the Awell API is revoked from the backend.
- This results in "Unauthorized" error in the AHP, which does not make sense to the user.

Solution:

- If the hosted session is complete, stop polling the `GetHostedSession` query.
- If the result of `GetHostedSession` fails because of Unauthorised error, show that the session has expired/completed instead of "Something went wrong".