### PR TITLE
ET-128: stop polling hostedSession query when session is complete

### DIFF
--- a/src/hooks/useHostedSession/useHostedSession.ts
+++ b/src/hooks/useHostedSession/useHostedSession.ts
@@ -41,18 +41,19 @@ export const useHostedSession = (): UseHostedSessionHook => {
 
   const pollInterval = isSessionCompleted ? undefined : POLLING_DELAY_MS
 
-  const { data, loading, error, refetch } = useGetHostedSessionQuery({
-    pollInterval,
-    onError: (error) => {
-      Sentry.captureException(error, {
-        contexts: {
-          graphql: {
-            query: 'GetHostedSession',
+  const { data, loading, error, refetch, stopPolling } =
+    useGetHostedSessionQuery({
+      pollInterval,
+      onError: (error) => {
+        Sentry.captureException(error, {
+          contexts: {
+            graphql: {
+              query: 'GetHostedSession',
+            },
           },
-        },
-      })
-    },
-  })
+        })
+      },
+    })
   const client = useApolloClient()
   const router = useRouter()
 
@@ -90,6 +91,12 @@ export const useHostedSession = (): UseHostedSessionHook => {
       })
     }
   })
+
+  useEffect(() => {
+    if (isSessionCompleted === true) {
+      stopPolling()
+    }
+  }, [isSessionCompleted])
 
   useEffect(() => {
     if (!isNil(data?.hostedSession?.session)) {

--- a/src/hooks/useHostedSession/useHostedSession.ts
+++ b/src/hooks/useHostedSession/useHostedSession.ts
@@ -93,7 +93,7 @@ export const useHostedSession = (): UseHostedSessionHook => {
   })
 
   useEffect(() => {
-    if (isSessionCompleted === true) {
+    if (isSessionCompleted) {
       stopPolling()
     }
   }, [isSessionCompleted])


### PR DESCRIPTION
After deploying #258, I did a test in development and the polling wasn't stopped after completion of the session.

We need to call `stopPolling` from the graphql query hook that explicitly stops the polling.