### PR TITLE
rollback-ui-lib0.1.72

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.6",
-    "@awell-health/ui-library": "0.1.72",
+    "@awell-health/ui-library": "0.1.71",
     "@awell-health/sol-scheduling": "0.3.9",
     "@formsort/react-embed": "^3.1.1",
     "@google-cloud/logging": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,10 +101,10 @@
     tailwindcss-animate "^1.0.7"
     zod "^3.21.4"
 
-"@awell-health/ui-library@0.1.72":
-  version "0.1.72"
-  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.72.tgz#d881488ebd4b0b757e9ea6ef505c776110eb006f"
-  integrity sha512-MGVU+ZlFf4tAIhpniaa9q+NuMGVwkZ0W5lWmpQF8k2NaioRGTWZzJFPX7acj07a/LS5f61eX8h+GrkzsYcElrA==
+"@awell-health/ui-library@0.1.71":
+  version "0.1.71"
+  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.71.tgz#8959baf577f05a8a63496b397107f3ddc8681d3c"
+  integrity sha512-AaHg1Gc7ZBUwcUGl5TXEWhxh5vvGYxlJWFMbLCnGJqPv/A0hMkaEjLhlpZIQBS4Tr6rrP1mhRmKOFLpaYazs9g==
   dependencies:
     "@calcom/embed-react" "^1.5.1"
     "@heroicons/react" "^2.1.3"


### PR DESCRIPTION
### **PR Type**
dependencies


___

### **Description**
- Rolled back the version of `@awell-health/ui-library` from 0.1.72 to 0.1.71 in `package.json`.
- This change is likely intended to address issues or incompatibilities introduced in version 0.1.72.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Rollback `@awell-health/ui-library` dependency version</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<li>Rolled back <code>@awell-health/ui-library</code> dependency version from 0.1.72 to <br>0.1.71.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/292/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information