### PR TITLE
bump ui-library to 0.1.78

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.6",
-    "@awell-health/ui-library": "0.1.77",
+    "@awell-health/ui-library": "0.1.78",
     "@awell-health/sol-scheduling": "0.3.11",
     "@formsort/react-embed": "^3.1.1",
     "@google-cloud/logging": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,10 +101,10 @@
     tailwindcss-animate "^1.0.7"
     zod "^3.21.4"
 
-"@awell-health/ui-library@0.1.77":
-  version "0.1.77"
-  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.77.tgz#ff0205b310b245a09d1384304c096979b4d09248"
-  integrity sha512-0E1LX2lO0Wy9AmDDdIPlzdwqKyQu8hwev7ztPTZ3lmWLFObLpcBwyVdnUBoGboFW0gvidGEjayQmjLT41lA5qg==
+"@awell-health/ui-library@0.1.78":
+  version "0.1.78"
+  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.78.tgz#60d69474aa8797eabe5ebdfb56a27ebec728bca8"
+  integrity sha512-A3MU6KBd4QUhccTPmehfAJybSorJKFZEp+jkvotqPMSXFq9/VqXhucftDr6jzkPpYNATAQXN+KMEfcH8WUn0ZQ==
   dependencies:
     "@calcom/embed-react" "^1.5.1"
     "@heroicons/react" "^2.1.3"


### PR DESCRIPTION
### **PR Type**
dependencies


___

### **Description**
- Updated the `@awell-health/ui-library` dependency to version `0.1.78` in `package.json`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump `@awell-health/ui-library` dependency version to 0.1.78</code></dd></summary>
<hr>

package.json

<li>Updated the <code>@awell-health/ui-library</code> dependency version from <code>0.1.77</code> to <br><code>0.1.78</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/296/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information