### PR TITLE
ET-365: fix warning loggings when API returns no providers or availabilities

### DIFF
--- a/pages/api/sol/providers/[id]/availability.ts
+++ b/pages/api/sol/providers/[id]/availability.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import { getAccessToken } from '../../../../../src/utils'
 import { type GetAvailabilitiesResponseType } from '@awell-health/sol-scheduling'
 import { getSolEnvSettings, API_ROUTES, API_METHODS } from '../../utils'
-import { omit } from 'lodash'
+import { omit, isEmpty } from 'lodash'
 import { log } from '../../../../../src/utils/logging'
 
 export default async function handler(
@@ -50,9 +50,9 @@ export default async function handler(
       })
     }
 
-    const jsonRes: GetAvailabilitiesResponseType | { data: string } =
-      await response.json()
-    if (jsonRes.data === '') {
+    const jsonRes: GetAvailabilitiesResponseType = await response.json()
+
+    if (isEmpty(jsonRes.data?.[id as string])) {
       log(
         {
           message: `${logMessage}: failed - no data returned`,
@@ -61,7 +61,7 @@ export default async function handler(
           responseText: response.statusText,
           url,
         },
-        'ERROR'
+        'WARNING'
       )
       return res.status(404).json({ data: [] })
     }

--- a/pages/api/sol/providers/index.ts
+++ b/pages/api/sol/providers/index.ts
@@ -5,7 +5,7 @@ import {
   GetProvidersResponseType,
 } from '@awell-health/sol-scheduling'
 import { getSolEnvSettings, API_ROUTES, API_METHODS } from '../utils'
-import { omit } from 'lodash'
+import { omit, isEmpty } from 'lodash'
 import { log } from '../../../../src/utils/logging'
 
 export default async function handler(
@@ -68,9 +68,9 @@ export default async function handler(
       })
     }
 
-    const jsonRes: GetProvidersResponseType | { data: string } =
-      await response.json()
-    if (jsonRes.data === '') {
+    const jsonRes: GetProvidersResponseType = await response.json()
+
+    if (isEmpty(jsonRes.data)) {
       log(
         {
           message: `${logMessage}: failed - no data returned`,
@@ -79,7 +79,7 @@ export default async function handler(
           responseText: response.statusText,
           url,
         },
-        'ERROR'
+        'WARNING'
       )
       return res.status(404).json({ data: [] })
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Improved the logging mechanism by changing the log level from 'ERROR' to 'WARNING' when no data is returned from the API.
- Utilized `isEmpty` from lodash to simplify and improve the accuracy of checking for empty data responses.
- Ensured consistent handling of empty data scenarios across provider availability and provider index API endpoints.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>availability.ts</strong><dd><code>Improve logging and data check for provider availability</code>&nbsp; </dd></summary>
<hr>

pages/api/sol/providers/[id]/availability.ts

<li>Added <code>isEmpty</code> from lodash to check for empty data.<br> <li> Changed logging level from 'ERROR' to 'WARNING' when no data is <br>returned.<br> <li> Simplified the condition to check for empty data.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/302/files#diff-b93b67db406e30556c7602678569cf1c8cc3fb53584bd5b2e3898abf30b3f5f2">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Improve logging and data check for providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pages/api/sol/providers/index.ts

<li>Added <code>isEmpty</code> from lodash to check for empty data.<br> <li> Changed logging level from 'ERROR' to 'WARNING' when no data is <br>returned.<br> <li> Simplified the condition to check for empty data.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/302/files#diff-a25e848a9831907f0e846538f9deb5f90b25cbc3154e01a4d6ea5e10b00dd6ab">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information