### PR TITLE
Bump ui library to v84

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.6",
-    "@awell-health/ui-library": "0.1.83",
+    "@awell-health/ui-library": "0.1.84",
     "@awell-health/sol-scheduling": "0.3.27",
     "@formsort/react-embed": "^3.1.1",
     "@google-cloud/logging": "^11.0.0",


### PR DESCRIPTION
### **PR Type**
dependencies


___

### **Description**
- Updated the `@awell-health/ui-library` dependency version in `package.json` from `0.1.83` to `0.1.84`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update `@awell-health/ui-library` dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<li>Updated <code>@awell-health/ui-library</code> dependency version from <code>0.1.83</code> to <br><code>0.1.84</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/311/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information