### PR TITLE
Improve error message on AHP so we can see which datapoints are invalid

### DIFF
--- a/src/hooks/useSubmitForm/utils.ts
+++ b/src/hooks/useSubmitForm/utils.ts
@@ -1,8 +1,16 @@
 import { ApolloError } from '@apollo/client'
+import { isNil } from 'lodash'
 
 export const getErrorMessage = (error: any, defaultMessage: string): string => {
   if (error instanceof ApolloError) {
-    return error.message
+    const errorMessage = error.graphQLErrors
+      .map((err: any) =>
+        !isNil(err?.extensions?.data?.value)
+          ? `Invalid ${err.extensions.data.dataPointValueType}: ${err.extensions.data.value}.`
+          : err.message
+      )
+      .join(' ')
+    return `${defaultMessage}\n${errorMessage}`
   }
   return defaultMessage
 }

--- a/src/hooks/useSubmitForm/utils.ts
+++ b/src/hooks/useSubmitForm/utils.ts
@@ -5,6 +5,7 @@ export const getErrorMessage = (error: any, defaultMessage: string): string => {
   if (error instanceof ApolloError) {
     const errorMessage = error.graphQLErrors
       .map((err: any) =>
+        !isNil(err?.extensions?.data?.dataPointValueType) &&
         !isNil(err?.extensions?.data?.value)
           ? `Invalid ${err.extensions.data.dataPointValueType}: ${err.extensions.data.value}.`
           : err.message


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix
Show a better error message when the backend fails to submit a form.



___

### **Description**
- Enhanced error message to include invalid data point details.

- Improved clarity by specifying data point type and value.

- Utilized `lodash`'s `isNil` for null/undefined checks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Enhanced error handling for invalid data points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/useSubmitForm/utils.ts

<li>Enhanced error message to include invalid data point details.<br> <li> Added logic to handle <code>dataPointValueType</code> and <code>value</code>.<br> <li> Used <code>lodash</code>'s <code>isNil</code> for null/undefined checks.


</details>


  </td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/327/files#diff-7dc155ee5715a7d6209c3d7741b2cc242e45eae240c4fbe2b8264d4615cefd4a">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information