### PR TITLE
[ET-251] Add styles for slate rich message classes

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,3 +20,7 @@ a {
   box-sizing: border-box;
 }
 
+.slate-ul,
+.slate-ol {
+  list-style: revert;
+}


### PR DESCRIPTION
So styles for Message Component from ui library has been overwrite by sol-scheduling. I applied fix for slate lists classes but maybe it make sense to check how sol is affecting default styling in general. I will describe more in the ticket.
