### PR TITLE
feat(activities): allow filter by track_id or activity_id

### DIFF
--- a/pages/api/startHostedActivitySessionViaHostedPagesLink/[hostedPagesLinkId].ts
+++ b/pages/api/startHostedActivitySessionViaHostedPagesLink/[hostedPagesLinkId].ts
@@ -19,7 +19,8 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Data>
 ) {
-  const { hostedPagesLinkId } = req.query as StartHostedActivitySessionParams
+  const { hostedPagesLinkId, track_id, activity_id } =
+    req.query as StartHostedActivitySessionParams
 
   const token = jwt.sign(
     {
@@ -67,5 +68,13 @@ export default async function handler(
   const { session_id, session_url } =
     data?.startHostedActivitySessionViaHostedPagesLink
 
-  res.status(200).json({ sessionId: session_id, sessionUrl: session_url })
+  let additionalParams = ''
+  if (!isNil(activity_id)) {
+    additionalParams += `&activity_id=${activity_id}`
+  } else if (!isNil(track_id)) {
+    additionalParams += `&track_id=${track_id}`
+  }
+  const sessionUrl = `${session_url}${additionalParams}`
+
+  res.status(200).json({ sessionId: session_id, sessionUrl })
 }

--- a/pages/api/startHostedPathwaySessionFromLink/[hostedPagesLinkId].ts
+++ b/pages/api/startHostedPathwaySessionFromLink/[hostedPagesLinkId].ts
@@ -8,6 +8,8 @@ import { JwtFeature } from '../../../lib'
 export type StartHostedCareflowSessionParams = {
   hostedPagesLinkId: string
   patient_identifier?: string
+  track_id?: string
+  activity_id?: string
 }
 
 export type StartHostedCareflowSessionPayload = {
@@ -34,7 +36,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Data>
 ) {
-  const { hostedPagesLinkId, patient_identifier } =
+  const { hostedPagesLinkId, patient_identifier, track_id, activity_id } =
     req.query as StartHostedCareflowSessionParams
 
   const token = jwt.sign(
@@ -83,6 +85,14 @@ export default async function handler(
     return
   }
 
-  const sessionUrl = data?.startHostedPathwaySessionFromLink.session_url
+  let additionalParams = ''
+  if (!isNil(activity_id)) {
+    additionalParams += `&activity_id=${activity_id}`
+  } else if (!isNil(track_id)) {
+    additionalParams += `&track_id=${track_id}`
+  }
+
+  const sessionUrl = `${data?.startHostedPathwaySessionFromLink.session_url}${additionalParams}`
+
   res.status(200).json({ sessionUrl })
 }

--- a/pages/c/[hostedPagesLinkId].tsx
+++ b/pages/c/[hostedPagesLinkId].tsx
@@ -14,7 +14,7 @@ import { LoadingPage } from '../../src/components'
 const HostedCareflowLink: NextPage = () => {
   const { query, isReady } = useRouter()
 
-  const { hostedPagesLinkId, patient_identifier } =
+  const { hostedPagesLinkId, patient_identifier, track_id, activity_id } =
     query as StartHostedCareflowSessionParams
 
   return (
@@ -24,6 +24,8 @@ const HostedCareflowLink: NextPage = () => {
           <StartHostedCareflowSessionFlow
             hostedPagesLinkId={hostedPagesLinkId}
             patient_identifier={patient_identifier}
+            track_id={track_id}
+            activity_id={activity_id}
           />
         )}
         {!isReady && <LoadingPage showLogoBox />}

--- a/pages/l/[hostedPagesLinkId].tsx
+++ b/pages/l/[hostedPagesLinkId].tsx
@@ -13,12 +13,17 @@ import { NoSSRComponent } from '../../src/components/NoSSR'
 const HostedPagesLink: NextPage = () => {
   const router = useRouter()
 
-  const { hostedPagesLinkId } = router.query as StartHostedActivitySessionParams
+  const { hostedPagesLinkId, track_id, activity_id } =
+    router.query as StartHostedActivitySessionParams
 
   return (
     <NoSSRComponent>
       <ThemeProvider accentColor={AWELL_BRAND_COLOR}>
-        <StartHostedActivitySessionFlow hostedPagesLinkId={hostedPagesLinkId} />
+        <StartHostedActivitySessionFlow
+          hostedPagesLinkId={hostedPagesLinkId}
+          track_id={track_id}
+          activity_id={activity_id}
+        />
       </ThemeProvider>
     </NoSSRComponent>
   )

--- a/src/components/Activities/Activities.tsx
+++ b/src/components/Activities/Activities.tsx
@@ -16,7 +16,6 @@ export const Activities: FC = () => {
   const { currentActivity, waitingForNewActivities } = useCurrentActivity()
   const [noActivities, setNoActivities] = useState(false)
   const { t } = useTranslation()
-
   useEffect(() => {
     let noActivitiesTimer: NodeJS.Timeout
     if (waitingForNewActivities) {

--- a/src/components/StartHostedActivitySessionFlow/StartHostedActivitySessionFlow.tsx
+++ b/src/components/StartHostedActivitySessionFlow/StartHostedActivitySessionFlow.tsx
@@ -18,14 +18,20 @@ type StartHostedActivitySessionFlowProps = StartHostedActivitySessionParams
 
 export const StartHostedActivitySessionFlow: FC<
   StartHostedActivitySessionFlowProps
-> = ({ hostedPagesLinkId }): JSX.Element => {
+> = ({ hostedPagesLinkId, track_id, activity_id }): JSX.Element => {
   const router = useRouter()
   const { t } = useTranslation()
-
-  const { data } = useSWR<StartHostedActivitySessionPayload>(
-    `/api/startHostedActivitySessionViaHostedPagesLink/${hostedPagesLinkId}`,
-    fetcher
-  )
+  const queryParams = new URLSearchParams()
+  if (!isNil(track_id) || !isNil(activity_id)) {
+    if (!isNil(track_id)) {
+      queryParams.set('track_id', track_id)
+    }
+    if (!isNil(activity_id)) {
+      queryParams.set('activity_id', activity_id)
+    }
+  }
+  const key = `/api/startHostedActivitySessionViaHostedPagesLink/${hostedPagesLinkId}?${queryParams.toString()}`
+  const { data } = useSWR<StartHostedActivitySessionPayload>(key, fetcher)
 
   const retry = () => {
     window.location.reload()

--- a/src/components/StartHostedPathwaySessionFlow/StartHostedPathwaySessionFlow.tsx
+++ b/src/components/StartHostedPathwaySessionFlow/StartHostedPathwaySessionFlow.tsx
@@ -17,13 +17,26 @@ type StartHostedCareflowSessionFlowProps = StartHostedCareflowSessionParams
 
 export const StartHostedCareflowSessionFlow: FC<
   StartHostedCareflowSessionFlowProps
-> = ({ hostedPagesLinkId, patient_identifier }): JSX.Element => {
+> = ({
+  hostedPagesLinkId,
+  patient_identifier,
+  track_id,
+  activity_id,
+}): JSX.Element => {
   const { t } = useTranslation()
   const startSessionUrl = `/api/startHostedPathwaySessionFromLink/${hostedPagesLinkId}`
-  const queryParams = isNil(patient_identifier)
-    ? ''
-    : `?patient_identifier=${patient_identifier}`
-  const key = `${startSessionUrl}${queryParams}`
+
+  const queryParams = new URLSearchParams()
+  if (!isNil(patient_identifier)) {
+    queryParams.set('patient_identifier', patient_identifier)
+  }
+  if (!isNil(track_id)) {
+    queryParams.set('track_id', track_id)
+  }
+  if (!isNil(activity_id)) {
+    queryParams.set('activity_id', activity_id)
+  }
+  const key = `${startSessionUrl}?${queryParams.toString()}`
   const { data } = useSWR<StartHostedCareflowSessionPayload>(key, fetcher)
 
   useEffect(() => {

--- a/src/hooks/useSessionActivities/graphql/Activity.graphql
+++ b/src/hooks/useSessionActivities/graphql/Activity.graphql
@@ -18,4 +18,7 @@ fragment Activity on Activity {
     release_id
     title
   }
+  context {
+    track_id
+  }
 }

--- a/src/types/generated/fragment-types.ts
+++ b/src/types/generated/fragment-types.ts
@@ -17,6 +17,8 @@
     ],
     "Payload": [
       "ActionPayload",
+      "ActivityPayload",
+      "ActivityTypesPayload",
       "AddActivityMetadataPayload",
       "AddIdentifierToPatientPayload",
       "AddTrackPayload",

--- a/src/types/generated/types-orchestration.tsx
+++ b/src/types/generated/types-orchestration.tsx
@@ -25,6 +25,8 @@ const defaultOptions = {} as const;
     ],
     "Payload": [
       "ActionPayload",
+      "ActivityPayload",
+      "ActivityTypesPayload",
       "AddActivityMetadataPayload",
       "AddIdentifierToPatientPayload",
       "AddTrackPayload",
@@ -232,9 +234,17 @@ export enum ActivityObjectType {
   Reminder = 'REMINDER',
   Stakeholder = 'STAKEHOLDER',
   Step = 'STEP',
+  Timer = 'TIMER',
   Track = 'TRACK',
   User = 'USER'
 }
+
+export type ActivityPayload = Payload & {
+  __typename?: 'ActivityPayload';
+  activity?: Maybe<Activity>;
+  code: Scalars['String'];
+  success: Scalars['Boolean'];
+};
 
 export enum ActivityResolution {
   Expired = 'EXPIRED',
@@ -269,6 +279,13 @@ export type ActivityTrack = {
   __typename?: 'ActivityTrack';
   id?: Maybe<Scalars['String']>;
   title: Scalars['String'];
+};
+
+export type ActivityTypesPayload = Payload & {
+  __typename?: 'ActivityTypesPayload';
+  activityTypes: Array<Scalars['String']>;
+  code: Scalars['String'];
+  success: Scalars['Boolean'];
 };
 
 export type AddActivityMetadataInput = {
@@ -600,7 +617,7 @@ export type DataPoint = {
   data_set_id: Scalars['String'];
   date: Scalars['String'];
   id: Scalars['ID'];
-  key: Scalars['String'];
+  key?: Maybe<Scalars['String']>;
   serialized_value?: Maybe<Scalars['String']>;
   valueType: DataPointValueType;
 };
@@ -685,6 +702,11 @@ export type DateConfig = {
 export type DateFilter = {
   gte?: InputMaybe<Scalars['String']>;
   lte?: InputMaybe<Scalars['String']>;
+};
+
+export type DateRangeInput = {
+  from: Scalars['SafeDate'];
+  to: Scalars['SafeDate'];
 };
 
 export type DecisionOutputsPayload = Payload & {
@@ -859,6 +881,15 @@ export type FilterActivitiesParams = {
   stakeholders?: InputMaybe<StringArrayFilter>;
 };
 
+export type FilterCareflowActivitiesParams = {
+  action?: InputMaybe<Array<Scalars['String']>>;
+  activity_status?: InputMaybe<Array<Scalars['String']>>;
+  activity_type?: InputMaybe<Array<Scalars['String']>>;
+  date_range?: InputMaybe<DateRangeInput>;
+  hide_system_activities?: InputMaybe<Scalars['Boolean']>;
+  stakeholders?: InputMaybe<Array<Scalars['String']>>;
+};
+
 export type FilterPathwayDataPointDefinitionsParams = {
   category?: InputMaybe<StringArrayFilter>;
   value_type?: InputMaybe<StringArrayFilter>;
@@ -986,6 +1017,7 @@ export type HostedSession = {
   stakeholder: HostedSessionStakeholder;
   status: HostedSessionStatus;
   success_url?: Maybe<Scalars['String']>;
+  user_context?: Maybe<HostedSessionUserContext>;
 };
 
 export type HostedSessionActivitiesPayload = Payload & {
@@ -1021,6 +1053,17 @@ export enum HostedSessionStatus {
   Completed = 'COMPLETED',
   Expired = 'EXPIRED'
 }
+
+export type HostedSessionUserContext = {
+  __typename?: 'HostedSessionUserContext';
+  stytch_member_email?: Maybe<Scalars['String']>;
+  stytch_member_id?: Maybe<Scalars['String']>;
+};
+
+export type HostedSessionUserContextInput = {
+  stytch_member_email?: InputMaybe<Scalars['String']>;
+  stytch_member_id?: InputMaybe<Scalars['String']>;
+};
 
 export type IdFilter = {
   eq?: InputMaybe<Scalars['String']>;
@@ -1651,6 +1694,7 @@ export type PublishedPathwayDefinitionsPayload = PaginationAndSortingPayload & {
 export type Query = {
   __typename?: 'Query';
   activities: ActivitiesPayload;
+  activity: ActivityPayload;
   adHocTracksByPathway: TracksPayload;
   adHocTracksByRelease: TracksPayload;
   apiCall: ApiCallPayload;
@@ -1658,6 +1702,8 @@ export type Query = {
   baselineInfo: BaselineInfoPayload;
   calculationAction: ActionPayload;
   calculationResults: CalculationResultsPayload;
+  careflowActivities: ActivitiesPayload;
+  careflowActivityTypes: ActivityTypesPayload;
   checklist: ChecklistPayload;
   clinicalNote: ClinicalNotePayload;
   decisionOutputs: DecisionOutputsPayload;
@@ -1714,6 +1760,11 @@ export type QueryActivitiesArgs = {
 };
 
 
+export type QueryActivityArgs = {
+  id: Scalars['String'];
+};
+
+
 export type QueryAdHocTracksByPathwayArgs = {
   pathway_id: Scalars['String'];
 };
@@ -1747,6 +1798,19 @@ export type QueryCalculationActionArgs = {
 export type QueryCalculationResultsArgs = {
   activity_id: Scalars['String'];
   pathway_id: Scalars['String'];
+};
+
+
+export type QueryCareflowActivitiesArgs = {
+  filters?: InputMaybe<FilterCareflowActivitiesParams>;
+  pagination?: InputMaybe<PaginationParams>;
+  pathway_id: Scalars['String'];
+  sorting?: InputMaybe<SortingParams>;
+};
+
+
+export type QueryCareflowActivityTypesArgs = {
+  careflow_id: Scalars['String'];
 };
 
 
@@ -1785,6 +1849,7 @@ export type QueryFilterStakeholdersArgs = {
 
 export type QueryFormArgs = {
   id: Scalars['String'];
+  pathway_id?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -1803,6 +1868,7 @@ export type QueryFormsArgs = {
 export type QueryGenerateRetoolEmbedUrlArgs = {
   groupIds: Array<Scalars['String']>;
   landingPageUuid: Scalars['String'];
+  releaseVersion?: InputMaybe<Scalars['String']>;
   userInfo: UserInfoParams;
 };
 
@@ -1858,6 +1924,7 @@ export type QueryPathwayDataPointDefinitionsArgs = {
 export type QueryPathwayDataPointsArgs = {
   activity_id?: InputMaybe<Scalars['String']>;
   data_point_definition_id?: InputMaybe<Scalars['String']>;
+  data_point_key?: InputMaybe<Scalars['String']>;
   pagination?: InputMaybe<PaginationParams>;
   pathway_id: Scalars['String'];
   sorting?: InputMaybe<SortingParams>;
@@ -2212,6 +2279,7 @@ export type StartHostedActivitySessionInput = {
   pathway_id: Scalars['String'];
   stakeholder_id: Scalars['String'];
   success_url?: InputMaybe<Scalars['String']>;
+  user_context?: InputMaybe<HostedSessionUserContextInput>;
 };
 
 export type StartHostedActivitySessionPayload = Payload & {
@@ -2221,6 +2289,7 @@ export type StartHostedActivitySessionPayload = Payload & {
   session_id: Scalars['String'];
   session_url: Scalars['String'];
   success: Scalars['Boolean'];
+  user_context?: Maybe<HostedSessionUserContext>;
 };
 
 export type StartHostedActivitySessionViaHostedPagesLinkInput = {
@@ -2249,9 +2318,12 @@ export type StartHostedPathwaySessionInput = {
   patient_id?: InputMaybe<Scalars['String']>;
   /** If no patient_id is provided this field will be used to uniquely identify the patient. */
   patient_identifier?: InputMaybe<IdentifierInput>;
+  /** Specify the stakeholder for the hosted session. If not provided, the stakeholder will be the patient by default */
+  stakeholder_definition_id?: InputMaybe<Scalars['String']>;
   success_url?: InputMaybe<Scalars['String']>;
   /** Time-to-live of the session in seconds. This defaults to the maximal value of 3600 seconds (one hour). */
   ttl?: InputMaybe<Scalars['Float']>;
+  user_context?: InputMaybe<HostedSessionUserContextInput>;
 };
 
 export type StartHostedPathwaySessionPayload = Payload & {
@@ -2262,6 +2334,7 @@ export type StartHostedPathwaySessionPayload = Payload & {
   session_url: Scalars['String'];
   stakeholder: HostedSessionStakeholder;
   success: Scalars['Boolean'];
+  user_context?: Maybe<HostedSessionUserContext>;
 };
 
 export type StartPathwayInput = {
@@ -2677,7 +2750,7 @@ export type CompleteExtensionActivityMutationVariables = Exact<{
 }>;
 
 
-export type CompleteExtensionActivityMutation = { __typename?: 'Mutation', completeExtensionActivity: { __typename?: 'CompleteExtensionActivityPayload', activity: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null } } };
+export type CompleteExtensionActivityMutation = { __typename?: 'Mutation', completeExtensionActivity: { __typename?: 'CompleteExtensionActivityPayload', activity: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null, context?: { __typename?: 'PathwayContext', track_id?: string | null } | null } } };
 
 export type EvaluateFormRulesMutationVariables = Exact<{
   input: EvaluateFormRulesInput;
@@ -2741,58 +2814,58 @@ export type MarkMessageAsReadMutationVariables = Exact<{
 }>;
 
 
-export type MarkMessageAsReadMutation = { __typename?: 'Mutation', markMessageAsRead: { __typename?: 'MarkMessageAsReadPayload', activity: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null } } };
+export type MarkMessageAsReadMutation = { __typename?: 'Mutation', markMessageAsRead: { __typename?: 'MarkMessageAsReadPayload', activity: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null, context?: { __typename?: 'PathwayContext', track_id?: string | null } | null } } };
 
-export type ActivityFragment = { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null };
+export type ActivityFragment = { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null, context?: { __typename?: 'PathwayContext', track_id?: string | null } | null };
 
 export type GetHostedSessionActivitiesQueryVariables = Exact<{
   only_stakeholder_activities?: InputMaybe<Scalars['Boolean']>;
 }>;
 
 
-export type GetHostedSessionActivitiesQuery = { __typename?: 'Query', hostedSessionActivities: { __typename?: 'HostedSessionActivitiesPayload', success: boolean, activities: Array<{ __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null }> } };
+export type GetHostedSessionActivitiesQuery = { __typename?: 'Query', hostedSessionActivities: { __typename?: 'HostedSessionActivitiesPayload', success: boolean, activities: Array<{ __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null, context?: { __typename?: 'PathwayContext', track_id?: string | null } | null }> } };
 
 export type OnSessionActivityCompletedSubscriptionVariables = Exact<{
   only_stakeholder_activities: Scalars['Boolean'];
 }>;
 
 
-export type OnSessionActivityCompletedSubscription = { __typename?: 'Subscription', sessionActivityCompleted: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null } };
+export type OnSessionActivityCompletedSubscription = { __typename?: 'Subscription', sessionActivityCompleted: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null, context?: { __typename?: 'PathwayContext', track_id?: string | null } | null } };
 
 export type OnSessionActivityCreatedSubscriptionVariables = Exact<{
   only_stakeholder_activities: Scalars['Boolean'];
 }>;
 
 
-export type OnSessionActivityCreatedSubscription = { __typename?: 'Subscription', sessionActivityCreated: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null } };
+export type OnSessionActivityCreatedSubscription = { __typename?: 'Subscription', sessionActivityCreated: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null, context?: { __typename?: 'PathwayContext', track_id?: string | null } | null } };
 
 export type OnSessionActivityExpiredSubscriptionVariables = Exact<{
   only_stakeholder_activities: Scalars['Boolean'];
 }>;
 
 
-export type OnSessionActivityExpiredSubscription = { __typename?: 'Subscription', sessionActivityExpired: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null } };
+export type OnSessionActivityExpiredSubscription = { __typename?: 'Subscription', sessionActivityExpired: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null, context?: { __typename?: 'PathwayContext', track_id?: string | null } | null } };
 
 export type OnSessionActivityUpdatedSubscriptionVariables = Exact<{
   only_stakeholder_activities: Scalars['Boolean'];
 }>;
 
 
-export type OnSessionActivityUpdatedSubscription = { __typename?: 'Subscription', sessionActivityUpdated: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null } };
+export type OnSessionActivityUpdatedSubscription = { __typename?: 'Subscription', sessionActivityUpdated: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null, context?: { __typename?: 'PathwayContext', track_id?: string | null } | null } };
 
 export type SubmitChecklistMutationVariables = Exact<{
   input: SubmitChecklistInput;
 }>;
 
 
-export type SubmitChecklistMutation = { __typename?: 'Mutation', submitChecklist: { __typename?: 'SubmitChecklistPayload', activity: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null } } };
+export type SubmitChecklistMutation = { __typename?: 'Mutation', submitChecklist: { __typename?: 'SubmitChecklistPayload', activity: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null, context?: { __typename?: 'PathwayContext', track_id?: string | null } | null } } };
 
 export type SubmitFormResponseMutationVariables = Exact<{
   input: SubmitFormResponseInput;
 }>;
 
 
-export type SubmitFormResponseMutation = { __typename?: 'Mutation', submitFormResponse: { __typename?: 'SubmitFormResponsePayload', activity: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null } } };
+export type SubmitFormResponseMutation = { __typename?: 'Mutation', submitFormResponse: { __typename?: 'SubmitFormResponsePayload', activity: { __typename?: 'Activity', id: string, date: string, status: ActivityStatus, form_display_mode?: FormDisplayMode | null, object: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string }, indirect_object?: { __typename?: 'ActivityObject', id: string, type: ActivityObjectType, name: string } | null, action_component?: { __typename?: 'ActionComponent', definition_id?: string | null, release_id?: string | null, title?: string | null } | null, context?: { __typename?: 'PathwayContext', track_id?: string | null } | null } } };
 
 export const QuestionFragmentDoc = gql`
     fragment Question on Question {
@@ -2899,6 +2972,9 @@ export const ActivityFragmentDoc = gql`
     definition_id
     release_id
     title
+  }
+  context {
+    track_id
   }
 }
     `;

--- a/types/StartHostedActivitySessionParams.ts
+++ b/types/StartHostedActivitySessionParams.ts
@@ -1,3 +1,5 @@
 export type StartHostedActivitySessionParams = {
   hostedPagesLinkId: string
+  track_id?: string
+  activity_id?: string
 }


### PR DESCRIPTION
### **User description**
Customers have asked to restrict the activities that can be completed for a given AHP session. Rather than restrict sessions specifically, we can use a simple filter mechanism to restrict the activities that can be shown.

This PR allows the creator of the link to restrict activities to a given track or activity, using a track_id or activity_id query param

loom [here](https://www.loom.com/share/369687a94f354c65a6bdb22c2db9b87c)


___

### **PR Type**
Enhancement


___

### **Description**
- Added filtering capabilities for activities using `track_id` or `activity_id`.

- Updated API endpoints to handle new query parameters.

- Enhanced UI components to support activity filtering.

- Extended GraphQL types and queries for activity context and filtering.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>[hostedPagesLinkId].ts</strong><dd><code>Add query parameters for activity and track filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-b03805edc83bdf1fc715b5d6ae5854a18e515d51fe905e9368d0d3a233687ee8">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>[hostedPagesLinkId].ts</strong><dd><code>Support track_id and activity_id in pathway session API</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-0d6c3f9265e435d4a073385ba5db3ca799b3d39e85cd91d65894b2499cbff3b6">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>[hostedPagesLinkId].tsx</strong><dd><code>Pass track_id and activity_id to hosted careflow session</code>&nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-6cb4997304ead0bef6cd917e91056500b1a81ba4ac7fc4d056b6610fa2e96a12">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>[hostedPagesLinkId].tsx</strong><dd><code>Pass track_id and activity_id to hosted activity session</code>&nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-38b9d66b9f887dfb442cc16c24c6ed25e0d3dfff74f7556dab941eee6a624961">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StartHostedActivitySessionFlow.tsx</strong><dd><code>Add query parameter handling for activity and track</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-2a4d8b025e05444a8f0eb661e020fec51ee3655c26b23ccda7c07465aad160a6">+12/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StartHostedPathwaySessionFlow.tsx</strong><dd><code>Handle query parameters for pathway session flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-010f00802a694924ec7448da6832532ec49487861c12b32b8d15d84d891e7a9b">+18/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useSessionActivities.ts</strong><dd><code>Add filtering logic for activities by track or activity ID</code></dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-ffad70670ed96fec7ade5ffc4d3e76444b36f97164914eb02af05ef62b4d9595">+20/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fragment-types.ts</strong><dd><code>Extend GraphQL fragment types for activity context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-7b3d6850d75fa93516d3492a538a334d0f8e3559ab61d66fc4397924af8f9b31">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types-orchestration.tsx</strong><dd><code>Add new GraphQL types and queries for activity filtering</code>&nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-4995b7e929870b0fe0dbce1750ade89d9c3276c442538495b3bceeb34d8b00d3">+87/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>StartHostedActivitySessionParams.ts</strong><dd><code>Add track_id and activity_id to session parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-339096f67120f9264fc72a83031bc5de8df0cc0cd625c82b751e470aaca6a451">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Activity.graphql</strong><dd><code>Extend Activity GraphQL fragment with track_id context</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-d1ab5896748063bcf9694ddf245f80312a1652ee4288e6d91ee9d856998e2f2d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Activities.tsx</strong><dd><code>Minor formatting adjustments in Activities component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/339/files#diff-212d5f3c432445e975d3e4c493ba6b851717b85d58654f6b976b39af2bf075cd">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>