### PR TITLE
REV-477: fix age preference

### DIFF
--- a/src/components/Extension/PrivateExtensions/actions/IntakeScheduling/IntakeScheduling.tsx
+++ b/src/components/Extension/PrivateExtensions/actions/IntakeScheduling/IntakeScheduling.tsx
@@ -163,6 +163,10 @@ const populateInitialPrefs = (
   providerPrefs: Omit<ActionFields, 'patientName' | 'providerId'>
 ) => {
   return {
+    /**
+     * When no age is provided, it will default to 30
+     * See: https://github.com/awell-health/sol-scheduling/pull/84/files
+     */
     age: providerPrefs.agePreference
       ? String(providerPrefs.agePreference)
       : undefined,


### PR DESCRIPTION
### **User description**
Needs https://github.com/awell-health/sol-scheduling/pull/84 to be merged first


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
Document default age behavior in comments
Reference external scheduling PR for context
Preserve existing age/gender preference mapping
Clarify handling when age is not provided


___

### Diagram Walkthrough


```mermaid
flowchart LR
  prefs["Provider preferences"] -- "agePreference missing" --> default["Defaults to 30 (external service)"]
  prefs -- "agePreference present" --> usePref["Use provided agePreference"]
  code["populateInitialPrefs"] -- "maps to" --> ageField["age field as string or undefined"]
  note["Inline comment + link"] -- "explains behavior" --> code
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IntakeScheduling.tsx</strong><dd><code>Add comment clarifying default age preference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Extension/PrivateExtensions/actions/IntakeScheduling/IntakeScheduling.tsx

<ul><li>Add inline comment explaining default age behavior.<br> <li> Link to external PR documenting default of 30.<br> <li> Keep existing age/gender mapping logic unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/370/files#diff-a89a9fac197c0d8893e45e4784f7fab58c59a8cd94e8ac34d5758a8d5ff3c99c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

