### PR TITLE
Fix subscription timing issue to prevent out-of-order activities

### DIFF
--- a/src/hooks/useSessionActivities/useSessionActivities.ts
+++ b/src/hooks/useSessionActivities/useSessionActivities.ts
@@ -27,9 +27,12 @@ interface UsePathwayActivitiesHook {
 }
 
 export const useSessionActivities = (): UsePathwayActivitiesHook => {
-  const variables = {
-    only_stakeholder_activities: true,
-  }
+  const variables = useMemo(
+    () => ({
+      only_stakeholder_activities: true,
+    }),
+    []
+  )
   const router = useRouter()
   const {
     data,
@@ -47,8 +50,20 @@ export const useSessionActivities = (): UsePathwayActivitiesHook => {
    * Set up subscriptions to automatically update the activities array in the cache
    * when activities are created, completed, or expired.
    * Using subscribeToMore ensures the subscription data is properly merged into the query result.
+   *
+   * Subscriptions are only enabled after the initial query returns at least one activity
+   * to prevent race conditions where subscription events arrive before the initial data,
+   * which could cause the wrong activity to be marked as current.
    */
   useEffect(() => {
+    // Only enable subscriptions after initial query returns at least one activity
+    const hasActivities =
+      (data?.hostedSessionActivities?.activities?.length ?? 0) > 0
+
+    if (loading || !hasActivities) {
+      return // Don't set up subscriptions yet
+    }
+
     // Subscribe to new activities being created
     const unsubscribeCreated =
       subscribeToMore<OnSessionActivityCreatedSubscription>({
@@ -170,13 +185,13 @@ export const useSessionActivities = (): UsePathwayActivitiesHook => {
         },
       })
 
-    // Cleanup subscriptions on unmount
+    // Cleanup subscriptions on unmount or when dependencies change
     return () => {
       unsubscribeCreated()
       unsubscribeCompleted()
       unsubscribeExpired()
     }
-  }, [])
+  }, [data, loading, subscribeToMore, variables])
 
   const filterActivity = (activity: Activity): boolean => {
     if (!isNil(router.query.activity_id)) {


### PR DESCRIPTION
### **User description**
- Only enable subscriptions after initial query returns at least one activity
- Prevents race condition where subscription events arrive before initial data
- Ensures activities are shown in chronological order
- Fixes issue where wrong activity could be marked as current


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Gate subscriptions until initial activities load

- Memoize `variables` to stabilize dependencies

- Add effect dependencies for subscription setup

- Improve cleanup on dependency changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Query["Initial activities query"] -- "returns >= 1 activity" --> Subs["Setup subscriptions (created/completed/expired)"]
  Query -- "loading or none" --> Delay["Defer subscriptions"]
  Vars["useMemo variables"] -- "stable deps" --> Effect["useEffect with deps"]
  Effect -- "cleanup on change/unmount" --> Cleanup["Unsubscribe handlers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useSessionActivities.ts</strong><dd><code>Gate subscriptions and stabilize effect with memoized variables</code></dd></summary>
<hr>

src/hooks/useSessionActivities/useSessionActivities.ts

<ul><li>Memoize <code>variables</code> via <code>useMemo</code>.<br> <li> Gate subscription setup until initial data has activities.<br> <li> Add dependencies to <code>useEffect</code> and enhance cleanup semantics.<br> <li> Update comment to document race-condition prevention.</ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/hosted-pages/pull/401/files#diff-ffad70670ed96fec7ade5ffc4d3e76444b36f97164914eb02af05ef62b4d9595">+20/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

