### PR TITLE
chore: send Sentry exception when we receive GetHostedSession errors

### DIFF
--- a/src/hooks/useHostedSession/useHostedSession.ts
+++ b/src/hooks/useHostedSession/useHostedSession.ts
@@ -204,6 +204,10 @@ export const useHostedSession = (): UseHostedSessionHook => {
       (err) => err.extensions?.code === 'UNAUTHORIZED'
     )
 
+    if (!unauthorizedError) {
+      Sentry.captureException(error)
+    }
+
     const message = unauthorizedError ? 'UNAUTHORIZED' : error.message
 
     return {


### PR DESCRIPTION
Adding some additional observability to see what error we get during polling. 