### PR TITLE
chore: bump @awell-health/ui-library to 0.1.148 (image upload camera capture)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.6",
     "@awell-health/sol-scheduling": "0.5.0",
-    "@awell-health/ui-library": "0.1.147",
+    "@awell-health/ui-library": "0.1.148",
     "@awell-health/design-system": "0.16.2",
     "@formsort/react-embed": "^3.1.1",
     "@google-cloud/logging": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,10 +93,10 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@awell-health/design-system@0.15.4":
-  version "0.15.4"
-  resolved "https://registry.yarnpkg.com/@awell-health/design-system/-/design-system-0.15.4.tgz#d2d0696c18f3cc46a573401ba599781b4a8f1678"
-  integrity sha512-wY27Uz/f16sta+hYbU2mfH+pM3jo4Rj1gzmg6Rakswv/jt+4tt7knO3+Dug7xrN9yyL7Ae1bEI6owkmRaGnKAw==
+"@awell-health/design-system@0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@awell-health/design-system/-/design-system-0.16.2.tgz#ad4ba74783e3575f35917f58592843952f863a59"
+  integrity sha512-pMUMNGNVijRMowd50deNRgkqceNGUXnCMzkQfYTbi+5iiuG53K1WYeNv5GJXGwExt3qYD13n9WtSF+SbNb1Omg==
   dependencies:
     "@mdxeditor/editor" "^3.40.0"
     "@remixicon/react" "^4.6.0"
@@ -111,6 +111,7 @@
     clsx "^2.1.1"
     date-fns "^4.1.0"
     react-day-picker "^9.5.0"
+    react-international-phone "^4.8.0"
     react-select "^5.8.0"
     react-tooltip "^5.28.0"
     react-use "^17.5.1"
@@ -119,10 +120,10 @@
     tailwind-merge "^3.3.0"
     tailwindcss-animate "^1.0.7"
 
-"@awell-health/design-system@0.16.2":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@awell-health/design-system/-/design-system-0.16.2.tgz#ad4ba74783e3575f35917f58592843952f863a59"
-  integrity sha512-pMUMNGNVijRMowd50deNRgkqceNGUXnCMzkQfYTbi+5iiuG53K1WYeNv5GJXGwExt3qYD13n9WtSF+SbNb1Omg==
+"@awell-health/design-system@0.16.6":
+  version "0.16.6"
+  resolved "https://registry.yarnpkg.com/@awell-health/design-system/-/design-system-0.16.6.tgz#1371fdd08f88d157fcd6938e56b3f35ea5c61972"
+  integrity sha512-JpuADoew7PXuXuPJ7YQcESjCiaCFwvYVluSxlqtK19kUQ2G7glGcGi2u2uWfTDmB5mJKLpT9fVjbx9qf3fecKw==
   dependencies:
     "@mdxeditor/editor" "^3.40.0"
     "@remixicon/react" "^4.6.0"
@@ -163,12 +164,12 @@
     tailwindcss-animate "^1.0.7"
     zod "^3.21.4"
 
-"@awell-health/ui-library@0.1.147":
-  version "0.1.147"
-  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.147.tgz#c3aabefa0a2b2b283352d1860ad1c9eea24760d2"
-  integrity sha512-72LeyDKTg+1xSrHK5XltdMWca56L6yMsfAZa5GUxEa56IpFLyhVeJOqRDjf96lv7xw7J495Y5iSaui4qAi26nw==
+"@awell-health/ui-library@0.1.148":
+  version "0.1.148"
+  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.148.tgz#5e8c4e75dae730f4aefda2c33c6cfb05bf9d9413"
+  integrity sha512-ZFRlGnYrzq3uqjpN8CBh5QnhBXAnwqsZKxrqvwKHyss6EXjFipxIG0gcTr6etZZ935b8OLXwiR3filIOenE0Lg==
   dependencies:
-    "@awell-health/design-system" "0.15.4"
+    "@awell-health/design-system" "0.16.6"
     "@calcom/embed-react" "^1.5.1"
     "@heroicons/react" "^2.1.3"
     axios "^1.7.7"


### PR DESCRIPTION
Bumps `@awell-health/ui-library` `0.1.147 → 0.1.148`, which makes image upload questions set `capture="environment"` on the file input so mobile browsers open the rear camera directly ([MDN: capture](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/capture)).

Implemented properly via a `capture` prop on design-system's `FileUpload` (design-system#257 → `0.16.6`, threaded through ui-library#235). ui-library's bundled design-system also moves `0.15.4 → 0.16.6` as part of that.

No source changes in hosted-pages — dependency bump + lockfile only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)