### PR TITLE
chore: bump @awell-health/ui-library to 0.1.149 (image upload file selection)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.6",
     "@awell-health/sol-scheduling": "0.5.0",
-    "@awell-health/ui-library": "0.1.148",
+    "@awell-health/ui-library": "0.1.149",
     "@awell-health/design-system": "0.16.2",
     "@formsort/react-embed": "^3.1.1",
     "@google-cloud/logging": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,10 +164,10 @@
     tailwindcss-animate "^1.0.7"
     zod "^3.21.4"
 
-"@awell-health/ui-library@0.1.148":
-  version "0.1.148"
-  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.148.tgz#5e8c4e75dae730f4aefda2c33c6cfb05bf9d9413"
-  integrity sha512-ZFRlGnYrzq3uqjpN8CBh5QnhBXAnwqsZKxrqvwKHyss6EXjFipxIG0gcTr6etZZ935b8OLXwiR3filIOenE0Lg==
+"@awell-health/ui-library@0.1.149":
+  version "0.1.149"
+  resolved "https://registry.yarnpkg.com/@awell-health/ui-library/-/ui-library-0.1.149.tgz#cad684b41e5a279365bbbcb69867c31af6865072"
+  integrity sha512-kEAk90Puriro1GFhl6MwEET9SDg+j8rsWv1jvCYv3SnkknTeztRuJqxqBinBPJyxe5o8kIq/86S5WG1eY+dsjA==
   dependencies:
     "@awell-health/design-system" "0.16.6"
     "@calcom/embed-react" "^1.5.1"


### PR DESCRIPTION
Bumps `@awell-health/ui-library` `0.1.148 → 0.1.149`.

Fixes the Android Chrome regression where the image upload's `capture="environment"` attribute forced the camera and hid file selection. Image uploads now append the legacy `;capture=camera` hint to the `accept` string instead, so the native chooser (camera + files/photos) is preserved.

Library change: awell-health/ui-library#236.

No source changes in hosted-pages — dependency bump + lockfile only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)