### PR TITLE
fix: safely tear down expired session requests

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,8 +33,12 @@ import { useConnectivity } from '../src/contexts/ConnectivityContext'
 import { useNetworkError } from '../src/contexts/NetworkErrorContext'
 import { useHostedSession } from '../src/hooks/useHostedSession'
 import { HostedSession } from '../src/hooks/useHostedSession/types'
-import { useSessionStorage } from '../src/hooks/useSessionStorage'
 import { HostedSessionLayout } from '../src/layouts'
+import { useAuthentication } from '../src/services/authentication'
+import {
+  finalizeTerminalGraphQLRequests,
+  useGraphQLRequestLifecycle,
+} from '../src/services/graphql'
 import { HostedSessionStatus } from '../src/types/generated/types-orchestration'
 import { validateLocale } from '../src/utils'
 import { serializeError } from '../src/utils/errors'
@@ -55,8 +59,9 @@ const Home: NextPageWithLayout = () => {
     startPolling,
     stopPolling,
   } = useHostedSession()
+  const requestLifecycle = useGraphQLRequestLifecycle()
   const { registerPollingTask } = useConnectivity()
-  const { removeItem: removeAccessToken } = useSessionStorage('accessToken', '')
+  const { clearAccessToken } = useAuthentication()
   const [logoOverride, setLogoOverride] = useLocalStorage(
     'awell-hp-logo-override',
     ''
@@ -72,19 +77,42 @@ const Home: NextPageWithLayout = () => {
   const [isCloseHostedSessionModalOpen, setIsCloseHostedSessionModalOpen] =
     useState(false)
   const [showInvalidSession, setShowInvalidSession] = useState(false)
+  const [terminalWriteError, setTerminalWriteError] = useState<
+    'failed' | 'timed-out'
+  >()
+  const terminalFinalizationRef = useRef<string>()
+  const isMountedRef = useRef(true)
+  const isSessionActive = session?.status === HostedSessionStatus.Active
+  const isSessionTerminal =
+    session?.status === HostedSessionStatus.Completed ||
+    session?.status === HostedSessionStatus.Expired
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
 
   // Keep refs to the latest Apollo polling controls so the registration effect
   // does not have to re-run (and thereby tear down the polling task) when
   // Apollo recreates the underlying ObservableQuery and rebinds these methods.
   const startPollingRef = useRef(startPolling)
   const stopPollingRef = useRef(stopPolling)
+  const isSessionActiveRef = useRef(isSessionActive)
   useEffect(() => {
     startPollingRef.current = startPolling
     stopPollingRef.current = stopPolling
+    isSessionActiveRef.current = isSessionActive
   })
 
   // Register hosted session polling with connectivity so it starts when connected and stops when offline/hidden
   useEffect(() => {
+    if (!isSessionActive) {
+      stopPollingRef.current()
+      return
+    }
+
     Sentry.logger?.info('Session polling effect ran', {
       category: 'session_polling',
       event_type: LogEvent.SESSION_POLLING_EFFECT_RAN,
@@ -93,6 +121,9 @@ const Home: NextPageWithLayout = () => {
 
     const cleanup = registerPollingTask({
       start: () => {
+        if (!isSessionActiveRef.current) {
+          return
+        }
         Sentry.logger?.info('Session startPolling called', {
           category: 'session_polling',
           event_type: LogEvent.SESSION_START_POLLING,
@@ -116,7 +147,7 @@ const Home: NextPageWithLayout = () => {
       })
       cleanup()
     }
-  }, [registerPollingTask, router.query.sessionId])
+  }, [registerPollingTask, router.query.sessionId, isSessionActive])
 
   const handleNetworkErrorRetry = useCallback(async () => {
     try {
@@ -147,13 +178,7 @@ const Home: NextPageWithLayout = () => {
         error: serializeError(err),
       })
     }
-  }, [
-    refetch,
-    resetNetworkErrorCount,
-    setNetworkError,
-    setShowInvalidSession,
-    router.query.sessionId,
-  ])
+  }, [refetch, resetNetworkErrorCount, setNetworkError, setShowInvalidSession])
 
   const { redirectAfterSession, shouldRedirect } = useRedirectAfterSession({
     setLogoOverride,
@@ -197,9 +222,54 @@ const Home: NextPageWithLayout = () => {
       })
       return
     }
+    if (terminalWriteError) {
+      return
+    }
+
+    const finishTerminalSession = async (redirectUrl?: string) => {
+      const terminalKey = `${session?.id}:${session?.status}`
+      if (terminalFinalizationRef.current === terminalKey) {
+        return
+      }
+      terminalFinalizationRef.current = terminalKey
+      const isCurrentFinalization = () =>
+        isMountedRef.current && terminalFinalizationRef.current === terminalKey
+
+      // New operations are already blocked. Do not clear authentication or
+      // navigate away until patient-data mutations have either settled or the
+      // patient has been shown a safe terminal error.
+      const result = await finalizeTerminalGraphQLRequests({
+        requestLifecycle,
+        clearAccessToken,
+        isCurrent: isCurrentFinalization,
+      })
+      if (!isCurrentFinalization()) {
+        return
+      }
+      if (result.status !== 'settled') {
+        Sentry.logger?.error(
+          'Terminal session could not safely finalize patient writes',
+          {
+            category: 'graphql_request_teardown',
+            sessionId: session?.id,
+            terminalStatus: session?.status,
+            result: result.status,
+            operations: result.operations,
+          }
+        )
+        setTerminalWriteError(result.status)
+        return
+      }
+      if (shouldRedirect && redirectUrl) {
+        redirectAfterSession(redirectUrl)
+      }
+    }
 
     switch (session?.status) {
       case HostedSessionStatus.Completed: {
+        resetNetworkErrorCount()
+        setNetworkError(false)
+        setShowInvalidSession(false)
         logger.info('Hosted session is completed', LogEvent.SESSION_COMPLETED, {
           sessionStatus: session?.status,
           session,
@@ -208,14 +278,13 @@ const Home: NextPageWithLayout = () => {
           category: 'session_complete',
           organization_slug: session?.organization_slug,
         })
-        // Remove access token when session is completed
-        removeAccessToken()
-        if (shouldRedirect) {
-          redirectAfterSession(session.success_url as string)
-        }
+        void finishTerminalSession(session.success_url as string)
         return
       }
       case HostedSessionStatus.Expired: {
+        resetNetworkErrorCount()
+        setNetworkError(false)
+        setShowInvalidSession(false)
         logger.info('Hosted session is expired', LogEvent.SESSION_EXPIRED, {
           sessionStatus: session?.status,
           session,
@@ -224,27 +293,38 @@ const Home: NextPageWithLayout = () => {
           category: 'session_expire',
           organization_slug: session?.organization_slug,
         })
-        // Remove access token when session is expired
-        removeAccessToken()
-        if (shouldRedirect) {
-          redirectAfterSession(session.cancel_url as string)
-        }
+        void finishTerminalSession(session.cancel_url as string)
         return
       }
       default: {
+        terminalFinalizationRef.current = undefined
+        setTerminalWriteError(undefined)
         logger.info('Hosted session is ongoing', LogEvent.SESSION_ONGOING, {
           session,
         })
         return
       }
     }
-  }, [session, shouldRedirect, redirectAfterSession, removeAccessToken])
+  }, [
+    session,
+    shouldRedirect,
+    redirectAfterSession,
+    clearAccessToken,
+    resetNetworkErrorCount,
+    requestLifecycle,
+    setNetworkError,
+    terminalWriteError,
+  ])
 
   // content now handled by SessionRouter component
   const logo = useLogo(theme, branding, logoOverride)
 
+  if (terminalWriteError) {
+    return <ErrorPage title={t('session.completion_error')} />
+  }
+
   // Show network error page if retry link failed after 3 attempts
-  if (hasNetworkError && networkErrorCount >= 3) {
+  if (!isSessionTerminal && hasNetworkError && networkErrorCount >= 3) {
     const sessionId = router.query.sessionId as string | undefined
     return (
       <NetworkErrorGate
@@ -259,7 +339,7 @@ const Home: NextPageWithLayout = () => {
   }
 
   // Show invalid session page after successful retry but no valid session
-  if (showInvalidSession) {
+  if (!isSessionTerminal && showInvalidSession) {
     const sessionId = router.query.sessionId as string | undefined
     const errorType = error === 'UNAUTHORIZED' ? 'unauthorized' : 'not_found'
     return (

--- a/src/components/Activities/context/ActivityProvider.tsx
+++ b/src/components/Activities/context/ActivityProvider.tsx
@@ -8,7 +8,10 @@ import { ErrorPage, LoadingPage } from '../../'
 import { useCompleteSession } from '../../../hooks/useCompleteSession'
 import { useHostedSession } from '../../../hooks/useHostedSession'
 import { useSessionActivities } from '../../../hooks/useSessionActivities'
-import { ActivityReferenceType } from '../../../types/generated/types-orchestration'
+import {
+  ActivityReferenceType,
+  HostedSessionStatus,
+} from '../../../types/generated/types-orchestration'
 import {
   HostedSessionError,
   captureHostedSessionError,
@@ -73,6 +76,7 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
   } = useSessionActivities()
   const { session } = useHostedSession()
   const { onCompleteSession, isCompleting } = useCompleteSession()
+  const isSessionActive = session?.status === HostedSessionStatus.Active
 
   // Array of strings combining activity id and status.
   // Used as a dependency for the effect to ensure it only runs when the set or status of activities changes,
@@ -86,6 +90,11 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
   // this useEffect drives whole AHP logic, only by activities being changed in apollo cache
   // and base on their status do we determine what to show to the user
   useEffect(() => {
+    if (!isSessionActive) {
+      stopPolling()
+      return
+    }
+
     const activityWithLogoOverride = activities.find(
       (a) => a.status === ActivityStatus.Active && a.metadata?.ahp_logo_override
     )
@@ -121,9 +130,14 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
         stopPolling()
       }
     }
-  }, [activityKeys])
+  }, [activityKeys, isSessionActive])
 
   useEffect(() => {
+    if (!isSessionActive) {
+      stopPolling()
+      return
+    }
+
     switch (state) {
       case 'polling': {
         startPolling(POLLING_INTERVAL)
@@ -141,6 +155,7 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
         }, pollingTimeout)
         return () => {
           clearTimeout(timer)
+          stopPolling()
         }
       }
       case 'polling-extended': {
@@ -158,6 +173,7 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
         }, MAX_POLLING_TIMEOUT)
         return () => {
           clearTimeout(timer)
+          stopPolling()
         }
       }
       case 'active-activity-found': {
@@ -169,7 +185,7 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
         break
       }
     }
-  }, [state, pollingTimeout])
+  }, [state, pollingTimeout, isSessionActive])
 
   useEffect(() => {
     logger.info(
@@ -186,10 +202,16 @@ export const ActivityProvider: FC<ActivityProviderProps> = ({ children }) => {
 
   useEffect(() => {
     // we're only handling individual activities here --
-    if (isActivityComplete && !isCompleting && router.query.sessionId) {
+    if (
+      isSessionActive &&
+      isActivityComplete &&
+      !isCompleting &&
+      router.query.sessionId
+    ) {
       void onCompleteSession(router.query.sessionId as string)
     }
   }, [
+    isSessionActive,
     isActivityComplete,
     isCompleting,
     router.query.sessionId,

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -9,6 +9,7 @@ import { useFileUpload } from '../../hooks/useFileUpload'
 import { useHostedSession } from '../../hooks/useHostedSession'
 import { useSubmitForm } from '../../hooks/useSubmitForm'
 import { masker } from '../../services/ErrorReporter'
+import { useGraphQLRequestLifecycle } from '../../services/graphql'
 import * as Sentry from '@sentry/nextjs'
 import { ErrorPage } from '../ErrorPage'
 import { LoadingPage } from '../LoadingPage'
@@ -25,6 +26,7 @@ import { mapForm } from './mapper'
 import {
   ActivityInputType,
   DynamicFormActivityInputs,
+  HostedSessionStatus,
 } from '../../types/generated/types-orchestration'
 
 interface FormProps {
@@ -57,6 +59,8 @@ export const Form: FC<FormProps> = ({ activity }) => {
   const { onSubmit, isSubmitting } = useSubmitForm(activity)
   const { branding, theme, session } = useHostedSession()
   const [getGcsSignedUrl] = useFileUpload()
+  const requestLifecycle = useGraphQLRequestLifecycle()
+  const isSessionActive = session?.status === HostedSessionStatus.Active
 
   useEffect(() => {
     if (activity.inputs?.type === ActivityInputType.Form) {
@@ -93,6 +97,10 @@ export const Form: FC<FormProps> = ({ activity }) => {
     async (
       response: Array<AnswerInput>
     ): Promise<Array<QuestionRuleResult>> => {
+      if (!isSessionActive) {
+        return []
+      }
+
       Sentry.logger?.info('Evaluating form rules', {
         category: 'evaluate_form_rules',
         form_id: activity.object.id,
@@ -107,6 +115,7 @@ export const Form: FC<FormProps> = ({ activity }) => {
       activity.object.id,
       session?.id,
       session?.organization_slug,
+      isSessionActive,
     ]
   )
 
@@ -131,10 +140,14 @@ export const Form: FC<FormProps> = ({ activity }) => {
 
   // Cleanup debounced function on unmount
   useEffect(() => {
+    if (!isSessionActive) {
+      debouncedEvaluateFormRules.cancel()
+    }
+
     return () => {
       debouncedEvaluateFormRules.cancel()
     }
-  }, [debouncedEvaluateFormRules])
+  }, [debouncedEvaluateFormRules, isSessionActive])
 
   const renderTraditionalForm =
     activity.form_display_mode &&
@@ -142,6 +155,10 @@ export const Form: FC<FormProps> = ({ activity }) => {
 
   const handleSubmit = useCallback(
     async (response: Array<any>) => {
+      if (!isSessionActive) {
+        return
+      }
+
       Sentry.logger?.info('Submitting form', {
         category: 'submit_form',
         form_id: activity.object.id,
@@ -163,6 +180,7 @@ export const Form: FC<FormProps> = ({ activity }) => {
       setPersistedFormAnswers,
       session?.id,
       session?.organization_slug,
+      isSessionActive,
     ]
   )
 
@@ -179,6 +197,10 @@ export const Form: FC<FormProps> = ({ activity }) => {
   const handleFileUpload = useCallback(
     async (file: File, config_slug?: string): Promise<string> => {
       try {
+        if (!isSessionActive) {
+          throw new Error('Cannot upload file for an inactive session')
+        }
+
         if (isNil(config_slug)) {
           throw new Error('Config ID is required')
         }
@@ -205,18 +227,36 @@ export const Form: FC<FormProps> = ({ activity }) => {
           console.warn('Error parsing URL:', e)
         }
 
-        const response = await fetch(upload_url, {
-          method: 'PUT',
-          body: file,
-          headers: {
-            'Content-Type': contentType,
-            'Content-Length': file.size.toString(),
-            Origin: window.location.origin,
-            ...(required_headers || {}),
-          },
-          credentials: 'omit',
-          mode: 'cors',
-        })
+        const uploadController = new AbortController()
+        requestLifecycle.trackRequest(
+          uploadController,
+          'settle',
+          `UploadFormFile:${activity.id}:${crypto.randomUUID()}`
+        )
+
+        let response: Response
+        try {
+          response = await fetch(upload_url, {
+            method: 'PUT',
+            body: file,
+            headers: {
+              'Content-Type': contentType,
+              'Content-Length': file.size.toString(),
+              Origin: window.location.origin,
+              ...(required_headers || {}),
+            },
+            credentials: 'omit',
+            mode: 'cors',
+            signal: uploadController.signal,
+          })
+          requestLifecycle.releaseRequest(
+            uploadController,
+            response.ok ? 'succeeded' : 'failed'
+          )
+        } catch (error) {
+          requestLifecycle.releaseRequest(uploadController, 'failed')
+          throw error
+        }
 
         if (!response.ok) {
           const errorText = await response.text()
@@ -231,7 +271,7 @@ export const Form: FC<FormProps> = ({ activity }) => {
         throw error
       }
     },
-    [activity.id, getGcsSignedUrl]
+    [activity.id, getGcsSignedUrl, isSessionActive, requestLifecycle]
   )
 
   const labels = {

--- a/src/components/GraphqlWrapper.tsx
+++ b/src/components/GraphqlWrapper.tsx
@@ -1,11 +1,16 @@
 import { ApolloProvider, ServerError, ServerParseError } from '@apollo/client'
 import { ErrorLink } from '@apollo/client/link/error'
 import * as Sentry from '@sentry/nextjs'
-import React, { FC, useCallback, useMemo } from 'react'
-import { createClient } from '../services/graphql'
+import React, { FC, useCallback, useEffect, useMemo } from 'react'
+import {
+  createClient,
+  createGraphQLRequestLifecycle,
+  GraphQLRequestLifecycleContext,
+} from '../services/graphql'
 import fragmentTypes from '../types/generated/fragment-types'
 import { useNetworkError } from '../contexts/NetworkErrorContext'
 import { HostedSessionError, captureHostedSessionError } from '../utils/errors'
+import { useAuthentication } from '../services/authentication'
 
 interface GraphqlWrapperProps {
   children?: React.ReactNode
@@ -13,6 +18,7 @@ interface GraphqlWrapperProps {
 
 const GraphqlWrapperInner: FC<GraphqlWrapperProps> = ({ children }) => {
   const { incrementNetworkErrorCount, setNetworkError } = useNetworkError()
+  const requestLifecycle = useMemo(createGraphQLRequestLifecycle, [])
 
   const onNetworkError: ErrorLink.ErrorHandler = useCallback(
     ({ operation, networkError }) => {
@@ -108,13 +114,27 @@ const GraphqlWrapperInner: FC<GraphqlWrapperProps> = ({ children }) => {
         cacheConfig: {
           possibleTypes: fragmentTypes.possibleTypes,
         },
+        requestLifecycle,
       }),
-    [onNetworkError]
+    [onNetworkError, requestLifecycle]
   )
 
-  return <ApolloProvider client={client}>{children}</ApolloProvider>
+  useEffect(() => {
+    return () => {
+      requestLifecycle.cancelPendingRequests({ abortSettling: true })
+      client.stop()
+    }
+  }, [client, requestLifecycle])
+
+  return (
+    <GraphQLRequestLifecycleContext.Provider value={requestLifecycle}>
+      <ApolloProvider client={client}>{children}</ApolloProvider>
+    </GraphQLRequestLifecycleContext.Provider>
+  )
 }
 
 export const GraphqlWrapper: FC<GraphqlWrapperProps> = ({ children }) => {
-  return <GraphqlWrapperInner>{children}</GraphqlWrapperInner>
+  const { sessionId } = useAuthentication()
+
+  return <GraphqlWrapperInner key={sessionId}>{children}</GraphqlWrapperInner>
 }

--- a/src/hooks/useChecklist/useChecklist.ts
+++ b/src/hooks/useChecklist/useChecklist.ts
@@ -1,6 +1,10 @@
 import type { ChecklistItem, Activity } from './types'
 import { useGetChecklistQuery } from './types'
 import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+} from '../../services/graphql'
+import {
   HostedSessionError,
   captureHostedSessionError,
 } from '../../utils/errors'
@@ -24,6 +28,13 @@ export const useChecklist = (activity: Activity): UseChecklistHook => {
   const { data, loading, error, refetch } = useGetChecklistQuery({
     variables,
     onError: (error) => {
+      if (
+        isGraphQLRequestCancellation(error) ||
+        isGraphQLMissingAuthorizationError(error)
+      ) {
+        return
+      }
+
       const hostedSessionError = new HostedSessionError(
         'Failed to get checklist',
         {
@@ -55,7 +66,11 @@ export const useChecklist = (activity: Activity): UseChecklistHook => {
     }
   }
 
-  if (error) {
+  if (
+    error &&
+    !isGraphQLRequestCancellation(error) &&
+    !isGraphQLMissingAuthorizationError(error)
+  ) {
     return {
       loading: false,
       error: error.message,
@@ -63,8 +78,15 @@ export const useChecklist = (activity: Activity): UseChecklistHook => {
     }
   }
 
-  // @ts-expect-error
-  const { items = [], title = '' } = data?.checklist.checklist
+  if (
+    error &&
+    (isGraphQLRequestCancellation(error) ||
+      isGraphQLMissingAuthorizationError(error))
+  ) {
+    return { loading: false, refetch }
+  }
+
+  const { items = [], title = '' } = data?.checklist?.checklist ?? {}
 
   const formatted_items = items.map((item: string, index: number) => {
     return { id: index.toString(), label: item }

--- a/src/hooks/useCompleteExtensionActivity/useCompleteExtensionActivity.ts
+++ b/src/hooks/useCompleteExtensionActivity/useCompleteExtensionActivity.ts
@@ -1,11 +1,17 @@
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'next-i18next'
 import { toast } from 'react-toastify'
+import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+} from '../../services/graphql'
 import { type DataPoints, useCompleteExtensionActivityMutation } from './types'
 import {
   HostedSessionError,
   captureHostedSessionError,
 } from '../../utils/errors'
+import { HostedSessionStatus } from '../../types/generated/types-orchestration'
+import { useHostedSession } from '../useHostedSession'
 
 interface UseCompleteExtensionActivityHook {
   onSubmit: (activity_id: string, data_points: DataPoints) => Promise<void>
@@ -17,9 +23,14 @@ export const useCompleteExtensionActivity =
     const { t } = useTranslation()
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [completeExtensionActivity] = useCompleteExtensionActivityMutation()
+    const { session } = useHostedSession()
 
     const onSubmit: UseCompleteExtensionActivityHook['onSubmit'] = useCallback(
       async (activity_id, data_points) => {
+        if (session?.status !== HostedSessionStatus.Active) {
+          return
+        }
+
         setIsSubmitting(true)
         const variables = {
           input: {
@@ -28,8 +39,20 @@ export const useCompleteExtensionActivity =
           },
         }
         try {
-          await completeExtensionActivity({ variables })
+          await completeExtensionActivity({
+            variables,
+            context: {
+              requestLifecyclePolicy: 'settle',
+            },
+          })
         } catch (error) {
+          if (
+            isGraphQLRequestCancellation(error) ||
+            isGraphQLMissingAuthorizationError(error)
+          ) {
+            return
+          }
+
           toast.error(t('activities.checklist.saving_error'))
           const hostedSessionError = new HostedSessionError(
             'Failed to complete extension activity',
@@ -54,7 +77,7 @@ export const useCompleteExtensionActivity =
           setIsSubmitting(false)
         }
       },
-      [completeExtensionActivity, t]
+      [completeExtensionActivity, session?.status, t]
     )
 
     return {

--- a/src/hooks/useCompleteSession/useCompleteSession.ts
+++ b/src/hooks/useCompleteSession/useCompleteSession.ts
@@ -1,6 +1,10 @@
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'next-i18next'
 import { toast } from 'react-toastify'
+import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+} from '../../services/graphql'
 import { useCompleteSessionMutation } from './types'
 import {
   HostedSessionError,
@@ -27,8 +31,20 @@ export const useCompleteSession = (): UseCompleteSessionHook => {
           },
         }
         try {
-          await completeSession({ variables })
+          await completeSession({
+            variables,
+            context: {
+              requestLifecyclePolicy: 'settle',
+            },
+          })
         } catch (error) {
+          if (
+            isGraphQLRequestCancellation(error) ||
+            isGraphQLMissingAuthorizationError(error)
+          ) {
+            return
+          }
+
           toast.error(t('session.completion_error'))
           const hostedSessionError = new HostedSessionError(
             'Failed to complete session',

--- a/src/hooks/useEvaluateFormRules/useEvaluateFormRules.ts
+++ b/src/hooks/useEvaluateFormRules/useEvaluateFormRules.ts
@@ -1,10 +1,16 @@
 import { GraphQLError } from 'graphql'
+import { HostedSessionStatus } from '../../types/generated/types-orchestration'
+import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+} from '../../services/graphql'
 import {
   HostedSessionError,
   captureHostedSessionError,
   serializeError,
 } from '../../utils/errors'
 import { LogEvent, logger } from '../../utils/logging'
+import { useHostedSession } from '../useHostedSession'
 import type { AnswerInput, QuestionRuleResult } from './types'
 import { useEvaluateFormRulesMutation } from './types'
 
@@ -18,6 +24,7 @@ export const useEvaluateFormRules = (
   form_id: string
 ): UseEvaluateFormRulesHook => {
   const [evaluateFormRulesMutation] = useEvaluateFormRulesMutation()
+  const { session } = useHostedSession()
 
   const handleError = (
     errors: any | GraphQLError[],
@@ -70,6 +77,10 @@ export const useEvaluateFormRules = (
   const evaluateFormRules = async (
     answers: Array<AnswerInput>
   ): Promise<Array<QuestionRuleResult>> => {
+    if (session?.status !== HostedSessionStatus.Active) {
+      return []
+    }
+
     const variables = {
       input: {
         form_id,
@@ -91,6 +102,13 @@ export const useEvaluateFormRules = (
       }
       return data.evaluateFormRules.results
     } catch (error) {
+      if (
+        isGraphQLRequestCancellation(error) ||
+        isGraphQLMissingAuthorizationError(error)
+      ) {
+        return []
+      }
+
       handleError(error, answers, variables)
       return []
     }

--- a/src/hooks/useExtensionActivity/useExtensionActivity.ts
+++ b/src/hooks/useExtensionActivity/useExtensionActivity.ts
@@ -1,8 +1,12 @@
-import { useTranslation } from 'react-i18next'
 import { useGetExtensionActivityDetailsQuery } from './types'
 import type { ExtensionActivityRecord } from './types'
 import { isNil } from 'lodash'
-import { useEffect } from 'react'
+import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+} from '../../services/graphql'
+import { HostedSessionStatus } from '../../types/generated/types-orchestration'
+import { useHostedSession } from '../useHostedSession'
 
 interface UseExtensionActivityHook {
   loading: boolean
@@ -12,7 +16,7 @@ interface UseExtensionActivityHook {
 }
 
 export const useExtensionActivity = (id: string): UseExtensionActivityHook => {
-  const { t } = useTranslation()
+  const { session } = useHostedSession()
 
   const { data, loading, error, refetch } = useGetExtensionActivityDetailsQuery(
     {
@@ -20,14 +24,15 @@ export const useExtensionActivity = (id: string): UseExtensionActivityHook => {
         id,
       },
       nextFetchPolicy: 'cache-first',
+      skip: session?.status !== HostedSessionStatus.Active,
     }
   )
 
-  useEffect(() => {
-    void refetch()
-  }, [id])
-
-  if (!isNil(error)) {
+  if (
+    !isNil(error) &&
+    !isGraphQLRequestCancellation(error) &&
+    !isGraphQLMissingAuthorizationError(error)
+  ) {
     return { loading: false, error: error.message, refetch }
   }
   if (loading) {

--- a/src/hooks/useFileUpload/useFileUpload.ts
+++ b/src/hooks/useFileUpload/useFileUpload.ts
@@ -1,4 +1,8 @@
 import { isNil } from 'lodash'
+import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+} from '../../services/graphql'
 import { useGetSignedUrlLazyQuery } from './types'
 import type { GetSignedUrlQueryVariables } from './types'
 import {
@@ -51,6 +55,13 @@ export const useFileUpload = (): [
 
         return data.getSignedUrl
       } catch (error) {
+        if (
+          isGraphQLRequestCancellation(error) ||
+          isGraphQLMissingAuthorizationError(error)
+        ) {
+          throw error
+        }
+
         const hostedSessionError = new HostedSessionError(
           'Failed to get signed URL for file upload',
           {

--- a/src/hooks/useHostedSession/index.ts
+++ b/src/hooks/useHostedSession/index.ts
@@ -1,1 +1,2 @@
-export { useHostedSession } from './useHostedSession'
+export { HostedSessionProvider, useHostedSession } from './useHostedSession'
+export type { UseHostedSessionHook } from './useHostedSession'

--- a/src/hooks/useHostedSession/useHostedSession.ts
+++ b/src/hooks/useHostedSession/useHostedSession.ts
@@ -3,8 +3,22 @@
 import { type ApolloQueryResult, useApolloClient } from '@apollo/client'
 import * as Sentry from '@sentry/nextjs'
 import { isNil } from 'lodash'
-import { useEffect, useState } from 'react'
-import { updateQuery } from '../../services/graphql'
+import {
+  createContext,
+  createElement,
+  type FC,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+  updateQuery,
+  useGraphQLRequestLifecycle,
+} from '../../services/graphql'
 import { Maybe } from '../../types'
 import {
   HostedSessionStatus,
@@ -32,7 +46,13 @@ const getOrganizationsWithAutoReplay = (): string[] => {
     .filter(Boolean)
 }
 
-interface UseHostedSessionHook {
+const isTerminalSessionStatus = (
+  status: HostedSessionStatus | undefined
+): boolean =>
+  status === HostedSessionStatus.Completed ||
+  status === HostedSessionStatus.Expired
+
+export interface UseHostedSessionHook {
   loading: boolean
   session?: HostedSession
   metadata?: SessionMetadata | null
@@ -40,17 +60,48 @@ interface UseHostedSessionHook {
   theme: CustomTheme
   error?: string
   refetch?: () => Promise<ApolloQueryResult<GetHostedSessionQuery>> | undefined
-  startPolling: (pollInterval: number) => void
+  startPolling: (_pollInterval: number) => void
   stopPolling: () => void
 }
 
-export const useHostedSession = (): UseHostedSessionHook => {
+const HostedSessionContext = createContext<UseHostedSessionHook | undefined>(
+  undefined
+)
+
+const useHostedSessionValue = (): UseHostedSessionHook => {
   const defaultTheme = getTheme()
 
   const [isSessionCompleted, setIsSessionCompleted] = useState(false)
+  const handledTerminalSessionRef = useRef<string | undefined>()
+  const stopPollingRef = useRef<() => void>(() => undefined)
+  const requestLifecycle = useGraphQLRequestLifecycle()
+
+  const handleTerminalSession = (updatedHostedSession: HostedSession) => {
+    if (!isTerminalSessionStatus(updatedHostedSession.status)) {
+      return
+    }
+
+    const terminalSessionKey = `${updatedHostedSession.id}:${updatedHostedSession.status}`
+    if (handledTerminalSessionRef.current === terminalSessionKey) {
+      return
+    }
+
+    handledTerminalSessionRef.current = terminalSessionKey
+    setIsSessionCompleted(true)
+    stopPollingRef.current()
+    requestLifecycle.cancelPendingRequests()
+  }
 
   const { data, loading, error, refetch, stopPolling, startPolling } =
-    useGetHostedSessionQuery()
+    useGetHostedSessionQuery({
+      onCompleted: (completedData) => {
+        const completedSession = completedData.hostedSession?.session
+        if (completedSession) {
+          handleTerminalSession(completedSession)
+        }
+      },
+    })
+  stopPollingRef.current = stopPolling
   const client = useApolloClient()
 
   const onHostedSessionCompleted = useOnHostedSessionCompletedSubscription()
@@ -61,8 +112,13 @@ export const useHostedSession = (): UseHostedSessionHook => {
   }: {
     updatedHostedSession: HostedSession
   }) => {
+    handleTerminalSession(updatedHostedSession)
+
+    const cachedQuery = client.readQuery<GetHostedSessionQuery>({
+      query: GetHostedSessionDocument,
+    })
     const updatedQuery = updateQuery<GetHostedSessionQuery, HostedSession>(
-      data as GetHostedSessionQuery,
+      (cachedQuery ?? data) as GetHostedSessionQuery,
       ['hostedSession', 'session'],
       updatedHostedSession
     )
@@ -70,13 +126,6 @@ export const useHostedSession = (): UseHostedSessionHook => {
       query: GetHostedSessionDocument,
       data: updatedQuery,
     })
-
-    if (
-      updatedHostedSession.status === HostedSessionStatus.Completed ||
-      updatedHostedSession.status === HostedSessionStatus.Expired
-    ) {
-      setIsSessionCompleted(true)
-    }
   }
 
   const hostedSession = data?.hostedSession?.session
@@ -167,13 +216,10 @@ export const useHostedSession = (): UseHostedSessionHook => {
   // Handle session completion/expiration status
   // Only runs when session status changes
   useEffect(() => {
-    if (
-      sessionStatus === HostedSessionStatus.Completed ||
-      sessionStatus === HostedSessionStatus.Expired
-    ) {
-      setIsSessionCompleted(true)
+    if (isTerminalSessionStatus(sessionStatus) && hostedSession) {
+      handleTerminalSession(hostedSession)
     }
-  }, [sessionStatus])
+  }, [sessionStatus, hostedSession])
 
   useEffect(() => {
     if (isSessionCompleted) {
@@ -199,16 +245,24 @@ export const useHostedSession = (): UseHostedSessionHook => {
     return { loading: true, theme: defaultTheme, startPolling, stopPolling }
   }
 
-  if (error) {
+  if (
+    error &&
+    !isGraphQLRequestCancellation(error) &&
+    !isTerminalSessionStatus(sessionStatus)
+  ) {
     const unauthorizedError = error.graphQLErrors?.find(
       (err) => err.extensions?.code === 'UNAUTHORIZED'
     )
+    const missingAuthorizationError = isGraphQLMissingAuthorizationError(error)
 
-    if (!unauthorizedError) {
+    if (!unauthorizedError && !missingAuthorizationError) {
       Sentry.captureException(error)
     }
 
-    const message = unauthorizedError ? 'UNAUTHORIZED' : error.message
+    const message =
+      unauthorizedError || missingAuthorizationError
+        ? 'UNAUTHORIZED'
+        : error.message
 
     return {
       loading: false,
@@ -230,4 +284,24 @@ export const useHostedSession = (): UseHostedSessionHook => {
     startPolling,
     stopPolling,
   }
+}
+
+export const HostedSessionProvider: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  const value = useHostedSessionValue()
+
+  return createElement(HostedSessionContext.Provider, { value }, children)
+}
+
+export const useHostedSession = (): UseHostedSessionHook => {
+  const hostedSession = useContext(HostedSessionContext)
+
+  if (!hostedSession) {
+    throw new Error(
+      'useHostedSession must be used within HostedSessionProvider'
+    )
+  }
+
+  return hostedSession
 }

--- a/src/hooks/useMessage/useMessage.ts
+++ b/src/hooks/useMessage/useMessage.ts
@@ -1,10 +1,16 @@
 import { useTranslation } from 'next-i18next'
 import { toast } from 'react-toastify'
 import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+} from '../../services/graphql'
+import {
   HostedSessionError,
   captureHostedSessionError,
 } from '../../utils/errors'
 import { LogEvent, logger } from '../../utils/logging'
+import { HostedSessionStatus } from '../../types/generated/types-orchestration'
+import { useHostedSession } from '../useHostedSession'
 import type { Activity, Message } from './types'
 import { useGetMessageQuery, useMarkMessageAsReadMutation } from './types'
 interface UseMessageActivityHook {
@@ -22,11 +28,20 @@ export const useMessage = (activity: Activity): UseMessageActivityHook => {
     object: { id: message_id },
   } = activity
   const [markMessageAsRead] = useMarkMessageAsReadMutation()
+  const { session } = useHostedSession()
 
   const variables = { id: message_id }
   const { data, loading, error, refetch } = useGetMessageQuery({
     variables,
+    skip: session?.status !== HostedSessionStatus.Active,
     onError: (error) => {
+      if (
+        isGraphQLRequestCancellation(error) ||
+        isGraphQLMissingAuthorizationError(error)
+      ) {
+        return
+      }
+
       const hostedSessionError = new HostedSessionError(
         'Failed to get message',
         {
@@ -53,6 +68,10 @@ export const useMessage = (activity: Activity): UseMessageActivityHook => {
   })
 
   const onRead = async () => {
+    if (session?.status !== HostedSessionStatus.Active) {
+      return
+    }
+
     const markMessageAsReadVariables = {
       input: {
         activity_id,
@@ -60,7 +79,12 @@ export const useMessage = (activity: Activity): UseMessageActivityHook => {
     }
 
     try {
-      await markMessageAsRead({ variables: markMessageAsReadVariables })
+      await markMessageAsRead({
+        variables: markMessageAsReadVariables,
+        context: {
+          requestLifecyclePolicy: 'settle',
+        },
+      })
       logger.info(
         `Message ${message_id} marked as read successfully for activity ${activity.object.name}`,
         LogEvent.MESSAGE_MARKED_AS_READ,
@@ -69,6 +93,13 @@ export const useMessage = (activity: Activity): UseMessageActivityHook => {
         }
       )
     } catch (error: any) {
+      if (
+        isGraphQLRequestCancellation(error) ||
+        isGraphQLMissingAuthorizationError(error)
+      ) {
+        return
+      }
+
       const hostedSessionError = new HostedSessionError(
         `Failed to mark message ${message_id} as read for activity ${activity.object.name}`,
         {
@@ -104,7 +135,11 @@ export const useMessage = (activity: Activity): UseMessageActivityHook => {
     }
   }
 
-  if (error) {
+  if (
+    error &&
+    !isGraphQLRequestCancellation(error) &&
+    !isGraphQLMissingAuthorizationError(error)
+  ) {
     return {
       error: error.message,
       loading: false,

--- a/src/hooks/useSessionActivities/useSessionActivities.ts
+++ b/src/hooks/useSessionActivities/useSessionActivities.ts
@@ -3,11 +3,17 @@ import isNil from 'lodash/isNil'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo } from 'react'
 import {
+  HostedSessionStatus,
   OnSessionActivityCompletedSubscription,
   OnSessionActivityCreatedSubscription,
   OnSessionActivityExpiredSubscription,
 } from '../../types/generated/types-orchestration'
 import { LogEvent, logger } from '../../utils/logging'
+import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+} from '../../services/graphql'
+import { useHostedSession } from '../useHostedSession'
 import {
   Activity,
   ActivityStatus,
@@ -27,6 +33,7 @@ interface UsePathwayActivitiesHook {
 }
 
 export const useSessionActivities = (): UsePathwayActivitiesHook => {
+  const { session } = useHostedSession()
   const variables = useMemo(
     () => ({
       only_stakeholder_activities: true,
@@ -44,6 +51,7 @@ export const useSessionActivities = (): UsePathwayActivitiesHook => {
     subscribeToMore,
   } = useGetHostedSessionActivitiesQuery({
     variables,
+    skip: session?.status !== HostedSessionStatus.Active,
   })
 
   /**
@@ -233,7 +241,12 @@ export const useSessionActivities = (): UsePathwayActivitiesHook => {
     activities,
     loading,
     isActivityComplete,
-    error: error?.message,
+    error:
+      error &&
+      !isGraphQLRequestCancellation(error) &&
+      !isGraphQLMissingAuthorizationError(error)
+        ? error.message
+        : undefined,
     refetch,
     startPolling,
     stopPolling,

--- a/src/hooks/useSessionStorage/index.ts
+++ b/src/hooks/useSessionStorage/index.ts
@@ -1,5 +1,5 @@
 import { defaultTo } from 'lodash'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 interface useSessionStorageHook {
   setValue: (value: string) => void
@@ -25,28 +25,30 @@ export const useSessionStorage = (
   })
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to sessionStorage.
-  const setValue = (value: Function | string): void => {
-    try {
-      // Allow value to be a function so we have same API as useState
-      const valueToStore =
-        value instanceof Function ? value(storedValue) : value
-      // Save state
-      setStoredValue(valueToStore)
-      // Save to local storage
-      if (typeof window !== 'undefined') {
-        window.sessionStorage.setItem(key, valueToStore)
-      }
-    } catch (error) {
-      console.warn('Error setting sessionStorage value: ', error)
-    }
-  }
+  const setValue = useCallback(
+    (value: Function | string): void => {
+      setStoredValue((previousValue) => {
+        const valueToStore =
+          value instanceof Function ? value(previousValue) : value
+        try {
+          if (typeof window !== 'undefined') {
+            window.sessionStorage.setItem(key, valueToStore)
+          }
+        } catch (error) {
+          console.warn('Error setting sessionStorage value: ', error)
+        }
+        return valueToStore
+      })
+    },
+    [key]
+  )
 
-  const removeItem = (): void => {
-    if (typeof window === 'undefined') {
-      return
-    }
+  const removeItem = useCallback((): void => {
+    if (typeof window === 'undefined') return
+
+    setStoredValue(initialValue)
     window.sessionStorage.removeItem(key)
-  }
+  }, [initialValue, key])
 
   return { storedValue, setValue, removeItem }
 }

--- a/src/hooks/useSubmitChecklist/useSubmitChecklist.ts
+++ b/src/hooks/useSubmitChecklist/useSubmitChecklist.ts
@@ -2,11 +2,17 @@ import { useTranslation } from 'next-i18next'
 import { useState } from 'react'
 import { toast } from 'react-toastify'
 import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+} from '../../services/graphql'
+import {
   HostedSessionError,
   captureHostedSessionError,
   serializeError,
 } from '../../utils/errors'
 import { LogEvent, logger } from '../../utils/logging'
+import { HostedSessionStatus } from '../../types/generated/types-orchestration'
+import { useHostedSession } from '../useHostedSession'
 import type { Activity } from './types'
 import { useSubmitChecklistMutation } from './types'
 
@@ -20,8 +26,13 @@ export const useSubmitChecklist = (activity: Activity): UseChecklistHook => {
   const { id: activity_id } = activity
   const [submitChecklist] = useSubmitChecklistMutation()
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const { session } = useHostedSession()
 
   const onSubmit = async () => {
+    if (session?.status !== HostedSessionStatus.Active) {
+      return
+    }
+
     setIsSubmitting(true)
     const variables = {
       input: {
@@ -37,7 +48,12 @@ export const useSubmitChecklist = (activity: Activity): UseChecklistHook => {
       }
     )
     try {
-      await submitChecklist({ variables })
+      await submitChecklist({
+        variables,
+        context: {
+          requestLifecyclePolicy: 'settle',
+        },
+      })
       logger.info(
         `Checklist ${activity.object.name} submitted successfully`,
         LogEvent.CHECKLIST_SUBMITTED,
@@ -46,6 +62,14 @@ export const useSubmitChecklist = (activity: Activity): UseChecklistHook => {
         }
       )
     } catch (error: any) {
+      if (
+        isGraphQLRequestCancellation(error) ||
+        isGraphQLMissingAuthorizationError(error)
+      ) {
+        setIsSubmitting(false)
+        return
+      }
+
       const hostedSessionError = new HostedSessionError(
         `Failed to submit checklist for activity ${activity.object.name}`,
         {

--- a/src/hooks/useSubmitForm/useSubmitForm.ts
+++ b/src/hooks/useSubmitForm/useSubmitForm.ts
@@ -3,6 +3,11 @@ import { useTranslation } from 'next-i18next'
 import { useState } from 'react'
 import { toast } from 'react-toastify'
 import {
+  isGraphQLMissingAuthorizationError,
+  isGraphQLRequestCancellation,
+} from '../../services/graphql'
+import { HostedSessionStatus } from '../../types/generated/types-orchestration'
+import {
   HostedSessionError,
   captureHostedSessionError,
   serializeError,
@@ -31,6 +36,10 @@ export const useSubmitForm = (activity: Activity): UseFormActivityHook => {
    * @returns true if the form response was successfully submitted
    */
   const onSubmit = async (response: Array<AnswerInput>): Promise<boolean> => {
+    if (session?.status !== HostedSessionStatus.Active) {
+      return false
+    }
+
     setIsSubmitting(true)
     const variables = {
       input: {
@@ -47,7 +56,12 @@ export const useSubmitForm = (activity: Activity): UseFormActivityHook => {
       }
     )
     try {
-      const { errors } = await submitFormResponse({ variables })
+      const { errors } = await submitFormResponse({
+        variables,
+        context: {
+          requestLifecyclePolicy: 'settle',
+        },
+      })
 
       if (!isNil(errors) && errors.length > 0) {
         throw new Error(
@@ -67,6 +81,14 @@ export const useSubmitForm = (activity: Activity): UseFormActivityHook => {
 
       return true
     } catch (error: any) {
+      if (
+        isGraphQLRequestCancellation(error) ||
+        isGraphQLMissingAuthorizationError(error)
+      ) {
+        setIsSubmitting(false)
+        return false
+      }
+
       const hostedSessionError = new HostedSessionError(
         `Failed to submit form response for activity ${activity.object.name}`,
         {

--- a/src/layouts/HostedSessionLayout.tsx
+++ b/src/layouts/HostedSessionLayout.tsx
@@ -6,6 +6,7 @@ import { NoSSRComponent } from '../components/NoSSR'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { NetworkErrorProvider } from '../contexts/NetworkErrorContext'
 import { ConnectivityProvider } from '../contexts/ConnectivityContext'
+import { HostedSessionProvider } from '../hooks/useHostedSession'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -26,10 +27,13 @@ export const HostedSessionLayout: FC<LayoutProps> = ({ children }) => {
               <GraphqlWrapper>
                 <NoSSRComponent>
                   {/*
-                    Styles need to be applied to the ErrorBoundary
-                    to make sure layout is rendered correctly.
+                    Keep session initialization inside the ErrorBoundary so
+                    malformed session or branding data renders the safe error
+                    page instead of crashing the application.
                   */}
-                  <ErrorBoundary>{children}</ErrorBoundary>
+                  <ErrorBoundary>
+                    <HostedSessionProvider>{children}</HostedSessionProvider>
+                  </ErrorBoundary>
                 </NoSSRComponent>
               </GraphqlWrapper>
             </ConnectivityProvider>

--- a/src/services/authentication/AuthenticationContext.ts
+++ b/src/services/authentication/AuthenticationContext.ts
@@ -3,11 +3,14 @@ import { createContext } from 'react'
 export interface AuthenticationContextInterface {
   isAuthenticated: boolean
   accessToken?: string
+  sessionId?: string
   error?: string
+  clearAccessToken: () => void
 }
 
 const initialContext = {
   isAuthenticated: false,
+  clearAccessToken: () => undefined,
 }
 
 export const AuthenticationContext =

--- a/src/services/authentication/AuthenticationProvider.tsx
+++ b/src/services/authentication/AuthenticationProvider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, useState } from 'react'
+import React, { FC, useCallback, useEffect, useRef, useState } from 'react'
 import { AuthenticationContext } from './AuthenticationContext'
 import { useSessionStorage } from '../../hooks/useSessionStorage'
 import { useRouter } from 'next/router'
@@ -10,7 +10,36 @@ interface AuthenticationProviderProps {
   children?: React.ReactNode
 }
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json())
+const AUTHENTICATION_TIMEOUT_MS = 15000
+
+type AuthenticationStatus =
+  | 'loading'
+  | 'authenticated'
+  | 'failed'
+  | 'terminated'
+
+export const fetchAuthenticationToken = async (url: string) => {
+  const controller = new AbortController()
+  const timeout = setTimeout(
+    () => controller.abort(),
+    AUTHENTICATION_TIMEOUT_MS
+  )
+
+  try {
+    const response = await fetch(url, { signal: controller.signal })
+    if (!response.ok) {
+      throw new Error(`Authentication request failed with ${response.status}`)
+    }
+    const data = await response.json()
+    if (typeof data?.token !== 'string' || data.token.length === 0) {
+      throw new Error('Authentication response did not include a token')
+    }
+
+    return { ...data, requestUrl: url }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
 
 /*
  * Authentication is done in the following steps:
@@ -22,17 +51,47 @@ export const AuthenticationProvider: FC<AuthenticationProviderProps> = ({
   children,
 }) => {
   const { t } = useTranslation()
-  const { storedValue: accessToken, setValue: setAccessToken } =
-    useSessionStorage('accessToken', '')
+  const {
+    storedValue: accessToken,
+    setValue: setAccessToken,
+    removeItem: removeAccessToken,
+  } = useSessionStorage('accessToken', '')
   const router = useRouter()
-  const [tokenLoading, setTokenLoading] = useState(true)
+  const [authenticationStatus, setAuthenticationStatus] =
+    useState<AuthenticationStatus>('loading')
+  const [authenticatedSessionId, setAuthenticatedSessionId] = useState<string>()
   const [isClient, setIsClient] = useState(false)
+  const authenticatedSessionIdRef = useRef<string>()
+  const terminatedSessionIdRef = useRef<string>()
   const previousTokenRef = useRef<string | null>(null)
+  const intentionalTokenClearRef = useRef(false)
+  const sessionId =
+    typeof router.query.sessionId === 'string'
+      ? router.query.sessionId
+      : undefined
+  const sessionTokenUrl = sessionId ? `/api/session/${sessionId}` : null
 
-  const { data, error } = useSwr(
-    router.query.sessionId ? `/api/session/${router.query.sessionId}` : null,
-    fetcher
+  const removeStoredAccessToken = useCallback(() => {
+    intentionalTokenClearRef.current = true
+    removeAccessToken()
+  }, [removeAccessToken])
+
+  const authenticationRequestUrl =
+    authenticationStatus === 'terminated' &&
+    terminatedSessionIdRef.current === sessionId
+      ? null
+      : sessionTokenUrl
+  const { data, error, mutate } = useSwr(
+    authenticationRequestUrl,
+    fetchAuthenticationToken
   )
+
+  const clearAccessToken = useCallback(() => {
+    terminatedSessionIdRef.current = sessionId
+    setAuthenticationStatus('terminated')
+    removeStoredAccessToken()
+    void mutate(undefined, false)
+  }, [mutate, removeStoredAccessToken, sessionId])
 
   // Set client-side flag after hydration to prevent hydration mismatches
   useEffect(() => {
@@ -40,23 +99,66 @@ export const AuthenticationProvider: FC<AuthenticationProviderProps> = ({
   }, [])
 
   useEffect(() => {
-    if (data?.token) {
-      setAccessToken(data?.token)
-      setTokenLoading(false)
+    if (
+      !data?.token ||
+      !sessionId ||
+      data.requestUrl !== sessionTokenUrl ||
+      terminatedSessionIdRef.current === sessionId
+    ) {
+      return
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data?.token])
+
+    if (accessToken !== data.token) {
+      setAccessToken(data.token)
+    }
+    authenticatedSessionIdRef.current = sessionId
+    setAuthenticatedSessionId(sessionId)
+    setAuthenticationStatus('authenticated')
+  }, [
+    accessToken,
+    data?.token,
+    data?.requestUrl,
+    sessionId,
+    sessionTokenUrl,
+    setAccessToken,
+  ])
+
+  useEffect(() => {
+    if (!router.isReady || !sessionId) {
+      return
+    }
+
+    if (authenticatedSessionIdRef.current !== sessionId) {
+      terminatedSessionIdRef.current = undefined
+      authenticatedSessionIdRef.current = undefined
+      setAuthenticatedSessionId(undefined)
+      setAuthenticationStatus('loading')
+      removeStoredAccessToken()
+    }
+  }, [removeStoredAccessToken, router.isReady, sessionId])
+
+  useEffect(() => {
+    if (error && sessionId && authenticatedSessionIdRef.current !== sessionId) {
+      setAuthenticationStatus('failed')
+    }
+  }, [error, sessionId])
 
   // Log invalid URL when condition is met
   useEffect(() => {
-    if (isClient && router.isReady && !router.query.sessionId) {
+    if (isClient && router.isReady && !sessionId) {
       Sentry.logger?.warn('Invalid URL - missing sessionId', {
         category: 'navigation',
         url: router.asPath,
         sessionId: router.query.sessionId,
       })
     }
-  }, [isClient, router.isReady, router.query.sessionId, router.asPath])
+  }, [
+    isClient,
+    router.isReady,
+    router.query.sessionId,
+    router.asPath,
+    sessionId,
+  ])
 
   // Log router readiness state
   useEffect(() => {
@@ -73,21 +175,27 @@ export const AuthenticationProvider: FC<AuthenticationProviderProps> = ({
   // Log token loading state
   useEffect(() => {
     Sentry.logger?.info(
-      tokenLoading ? 'Token is loading' : 'Token loading completed',
+      authenticationStatus === 'loading'
+        ? 'Token is loading'
+        : `Authentication status changed to ${authenticationStatus}`,
       {
         category: 'authentication',
         sessionId: router.query.sessionId,
       }
     )
-  }, [tokenLoading, router.query.sessionId])
+  }, [authenticationStatus, router.query.sessionId])
 
   // Log unexpected token clearing for observability
   useEffect(() => {
     if (previousTokenRef.current && !accessToken) {
-      Sentry.logger?.error('Access token was unexpectedly cleared', {
-        category: 'authentication',
-        sessionId: router.query.sessionId,
-      })
+      if (intentionalTokenClearRef.current) {
+        intentionalTokenClearRef.current = false
+      } else {
+        Sentry.logger?.error('Access token was unexpectedly cleared', {
+          category: 'authentication',
+          sessionId: router.query.sessionId,
+        })
+      }
     }
     previousTokenRef.current = accessToken
   }, [accessToken, router.query.sessionId])
@@ -95,16 +203,42 @@ export const AuthenticationProvider: FC<AuthenticationProviderProps> = ({
   const authenticationContext = {
     isAuthenticated: accessToken !== '',
     accessToken,
-    error,
+    sessionId: authenticatedSessionId,
+    error: authenticationStatus === 'failed' ? error : undefined,
+    clearAccessToken,
   }
+  const isSwitchingSession =
+    authenticatedSessionId !== undefined &&
+    sessionId !== undefined &&
+    authenticatedSessionId !== sessionId
 
   // Only check for missing sessionId on client-side after hydration
-  if (isClient && router.isReady && !router.query.sessionId) {
+  if (isClient && router.isReady && !sessionId) {
     return <ErrorPage title={t('session.invalid_url')} />
   }
 
+  // Block the previous session tree synchronously when the URL changes. Effects
+  // run after paint, which is too late for patient/session isolation.
+  if (isSwitchingSession) {
+    return <LoadingPage showLogoBox={true} />
+  }
+
+  if (authenticationStatus === 'failed') {
+    return (
+      <ErrorPage
+        title={t('session.loading_error')}
+        onRetry={() => {
+          setAuthenticationStatus('loading')
+          void mutate().catch(() => {
+            setAuthenticationStatus('failed')
+          })
+        }}
+      />
+    )
+  }
+
   // Wait while token is being generated
-  if (!router.isReady || tokenLoading) {
+  if (!router.isReady || authenticationStatus === 'loading') {
     return <LoadingPage showLogoBox={true} />
   }
 

--- a/src/services/graphql/GraphQLRequestLifecycleContext.ts
+++ b/src/services/graphql/GraphQLRequestLifecycleContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react'
+import type { GraphQLRequestLifecycle } from './apollo-client'
+
+export const GraphQLRequestLifecycleContext = createContext<
+  GraphQLRequestLifecycle | undefined
+>(undefined)
+
+export const useGraphQLRequestLifecycle = (): GraphQLRequestLifecycle => {
+  const requestLifecycle = useContext(GraphQLRequestLifecycleContext)
+
+  if (!requestLifecycle) {
+    throw new Error(
+      'useGraphQLRequestLifecycle must be used within GraphqlWrapper'
+    )
+  }
+
+  return requestLifecycle
+}

--- a/src/services/graphql/apollo-client.ts
+++ b/src/services/graphql/apollo-client.ts
@@ -6,6 +6,7 @@ import {
   InMemoryCache,
   InMemoryCacheConfig,
   NormalizedCacheObject,
+  Observable,
   split,
 } from '@apollo/client'
 import { ErrorLink, onError } from '@apollo/client/link/error'
@@ -13,7 +14,7 @@ import { RetryLink } from '@apollo/client/link/retry'
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { getMainDefinition } from '@apollo/client/utilities'
 import { createClient as createWebsocketClient } from 'graphql-ws'
-import type { Message } from 'graphql-ws'
+import type { Client as GraphQLWsClient, Message } from 'graphql-ws'
 import { isNil } from 'lodash'
 import * as Sentry from '@sentry/nextjs'
 import { serializeError } from '../../utils/errors'
@@ -24,6 +25,277 @@ const GRAPHQL_WS_KEEPALIVE_TIMEOUT_MS = 5000
 const GRAPHQL_WS_KEEPALIVE_TIMEOUT_CODE = 4408
 const GRAPHQL_WS_KEEPALIVE_TIMEOUT_REASON = 'Request Timeout'
 const GRAPHQL_WS_CONNECTION_ACK_TIMEOUT_MS = 10000
+const GRAPHQL_REQUEST_CANCELLED = 'GRAPHQL_REQUEST_CANCELLED'
+const GRAPHQL_AUTHORIZATION_MISSING = 'GRAPHQL_AUTHORIZATION_MISSING'
+
+export interface GraphQLRequestLifecycle {
+  readonly isTerminated: boolean
+  trackRequest: (
+    _controller: AbortController,
+    _policy: GraphQLRequestTeardownPolicy,
+    _operationIdentity?: string
+  ) => void
+  releaseRequest: (
+    _controller: AbortController,
+    _outcome?: GraphQLRequestOutcome
+  ) => boolean
+  trackWebSocketClient: (_client: GraphQLWsClient) => void
+  cancelPendingRequests: (_options?: { abortSettling?: boolean }) => void
+  waitForSettlingRequests: (
+    _timeoutMs?: number
+  ) => Promise<GraphQLSettlingResult>
+}
+
+export type GraphQLRequestTeardownPolicy = 'abort' | 'settle'
+export type GraphQLRequestOutcome = 'succeeded' | 'failed'
+export type GraphQLSettlingResult =
+  | { status: 'settled' }
+  | { status: 'failed'; operations: string[] }
+  | { status: 'timed-out'; operations: string[] }
+
+interface SettlingRequest {
+  operationIdentity: string
+  attempt: number
+}
+
+export const createGraphQLRequestLifecycle = (): GraphQLRequestLifecycle => {
+  const abortableRequestControllers = new Set<AbortController>()
+  const settlingRequestControllers = new Map<AbortController, SettlingRequest>()
+  const failedSettlingOperations = new Map<string, number>()
+  const latestSuccessfulAttempts = new Map<string, number>()
+  const operationAttempts = new Map<string, number>()
+  const activeWebSocketClients = new Set<GraphQLWsClient>()
+  const settlingRequestWaiters = new Set<
+    (_result: GraphQLSettlingResult) => void
+  >()
+  let isTerminated = false
+
+  const getFailedOperations = (): string[] =>
+    Array.from(failedSettlingOperations.keys())
+
+  const getSettlingResult = (): GraphQLSettlingResult =>
+    failedSettlingOperations.size > 0
+      ? { status: 'failed', operations: getFailedOperations() }
+      : { status: 'settled' }
+
+  const resolveSettlingRequestWaiters = () => {
+    if (settlingRequestControllers.size > 0) {
+      return
+    }
+    const result = getSettlingResult()
+    settlingRequestWaiters.forEach((resolve) => resolve(result))
+    settlingRequestWaiters.clear()
+  }
+
+  return {
+    get isTerminated() {
+      return isTerminated
+    },
+    trackRequest: (controller, policy, operationIdentity = 'unknown') => {
+      if (isTerminated) {
+        controller.abort()
+        return
+      }
+      if (policy === 'settle') {
+        const attempt = (operationAttempts.get(operationIdentity) ?? 0) + 1
+        operationAttempts.set(operationIdentity, attempt)
+        settlingRequestControllers.set(controller, {
+          operationIdentity,
+          attempt,
+        })
+      } else {
+        abortableRequestControllers.add(controller)
+      }
+    },
+    releaseRequest: (controller, outcome = 'succeeded') => {
+      const wasAbortable = abortableRequestControllers.delete(controller)
+      const settlingRequest = settlingRequestControllers.get(controller)
+      const wasSettling = settlingRequestControllers.delete(controller)
+      if (wasSettling && settlingRequest) {
+        const { operationIdentity, attempt } = settlingRequest
+        if (outcome === 'failed') {
+          if (isTerminated) {
+            const latestSuccessfulAttempt =
+              latestSuccessfulAttempts.get(operationIdentity) ?? 0
+            if (attempt > latestSuccessfulAttempt) {
+              failedSettlingOperations.set(operationIdentity, attempt)
+            }
+          }
+        } else {
+          latestSuccessfulAttempts.set(operationIdentity, attempt)
+          const failedAttempt =
+            failedSettlingOperations.get(operationIdentity) ?? 0
+          if (failedAttempt <= attempt) {
+            failedSettlingOperations.delete(operationIdentity)
+          }
+          // A newer successful attempt supersedes older in-flight attempts for
+          // the same logical write. They must not keep terminal teardown open
+          // or later reintroduce a failure.
+          settlingRequestControllers.forEach(
+            (activeRequest, activeController) => {
+              if (
+                activeRequest.operationIdentity === operationIdentity &&
+                activeRequest.attempt < attempt
+              ) {
+                settlingRequestControllers.delete(activeController)
+                activeController.abort()
+              }
+            }
+          )
+        }
+        resolveSettlingRequestWaiters()
+      }
+      return wasAbortable || wasSettling
+    },
+    trackWebSocketClient: (client) => {
+      activeWebSocketClients.add(client)
+    },
+    cancelPendingRequests: ({ abortSettling = false } = {}) => {
+      isTerminated = true
+
+      abortableRequestControllers.forEach((controller) => {
+        controller.abort()
+      })
+      abortableRequestControllers.clear()
+
+      if (abortSettling) {
+        settlingRequestControllers.forEach((request, controller) => {
+          const latestSuccessfulAttempt =
+            latestSuccessfulAttempts.get(request.operationIdentity) ?? 0
+          if (request.attempt > latestSuccessfulAttempt) {
+            failedSettlingOperations.set(
+              request.operationIdentity,
+              request.attempt
+            )
+          }
+          controller.abort()
+        })
+        settlingRequestControllers.clear()
+        resolveSettlingRequestWaiters()
+      }
+
+      activeWebSocketClients.forEach((client) => {
+        const disposal = client.dispose()
+        if (disposal) {
+          void disposal.catch(() => undefined)
+        }
+      })
+      activeWebSocketClients.clear()
+    },
+    waitForSettlingRequests: (timeoutMs = 10000) => {
+      if (settlingRequestControllers.size === 0) {
+        return Promise.resolve(getSettlingResult())
+      }
+
+      return new Promise<GraphQLSettlingResult>((resolve) => {
+        let timeout: ReturnType<typeof setTimeout> | undefined
+        const finish = (result: GraphQLSettlingResult) => {
+          if (timeout) {
+            clearTimeout(timeout)
+          }
+          settlingRequestWaiters.delete(finish)
+          resolve(result)
+        }
+        settlingRequestWaiters.add(finish)
+        timeout = setTimeout(() => {
+          const operations = Array.from(
+            settlingRequestControllers.values(),
+            ({ operationIdentity }) => operationIdentity
+          )
+          Sentry.logger?.warn(
+            'In-flight writes exceeded the session teardown grace period',
+            {
+              category: 'graphql_request_teardown',
+              pendingRequestCount: settlingRequestControllers.size,
+              operations,
+              timeoutMs,
+            }
+          )
+          settlingRequestWaiters.delete(finish)
+          resolve({ status: 'timed-out', operations })
+        }, timeoutMs)
+      })
+    },
+  }
+}
+
+export class GraphQLRequestCancelledError extends Error {
+  constructor(operationName?: string) {
+    super(
+      operationName
+        ? `${GRAPHQL_REQUEST_CANCELLED}: ${operationName}`
+        : GRAPHQL_REQUEST_CANCELLED
+    )
+    this.name = 'GraphQLRequestCancelledError'
+  }
+}
+
+export class GraphQLMissingAuthorizationError extends Error {
+  constructor(operationName?: string) {
+    super(
+      operationName
+        ? `${GRAPHQL_AUTHORIZATION_MISSING}: ${operationName}`
+        : GRAPHQL_AUTHORIZATION_MISSING
+    )
+    this.name = 'GraphQLMissingAuthorizationError'
+  }
+}
+
+const hasNestedError = (
+  error: unknown,
+  predicate: (_candidate: { name?: string; message?: string }) => boolean,
+  seen = new Set<object>()
+): boolean => {
+  if (typeof error !== 'object' || error === null) {
+    return false
+  }
+
+  if (seen.has(error)) {
+    return false
+  }
+  seen.add(error)
+
+  const candidate = error as {
+    name?: string
+    message?: string
+    networkError?: unknown
+    cause?: unknown
+    originalError?: unknown
+  }
+
+  return (
+    predicate(candidate) ||
+    hasNestedError(candidate.networkError, predicate, seen) ||
+    hasNestedError(candidate.cause, predicate, seen) ||
+    hasNestedError(candidate.originalError, predicate, seen)
+  )
+}
+
+export const isGraphQLRequestCancellation = (error: unknown): boolean => {
+  if (
+    typeof DOMException !== 'undefined' &&
+    error instanceof DOMException &&
+    error.name === 'AbortError'
+  ) {
+    return true
+  }
+
+  return hasNestedError(
+    error,
+    ({ name, message }) =>
+      name === 'AbortError' ||
+      name === 'GraphQLRequestCancelledError' ||
+      message?.startsWith(GRAPHQL_REQUEST_CANCELLED) === true
+  )
+}
+
+export const isGraphQLMissingAuthorizationError = (error: unknown): boolean =>
+  hasNestedError(
+    error,
+    ({ name, message }) =>
+      name === 'GraphQLMissingAuthorizationError' ||
+      message?.startsWith(GRAPHQL_AUTHORIZATION_MISSING) === true
+  )
 
 const getCloseEventContext = (
   closeOrError: unknown
@@ -69,20 +341,146 @@ const getCloseCode = (closeOrError: unknown): number | undefined => {
   return typeof code === 'number' ? code : undefined
 }
 
+const getOperationIdentity = (
+  operationName: string,
+  variables: Record<string, unknown>
+): string => {
+  const input =
+    typeof variables.input === 'object' && variables.input !== null
+      ? (variables.input as Record<string, unknown>)
+      : {}
+  const identifierCandidates = [
+    input.activity_id,
+    input.session_id,
+    input.form_id,
+    input.id,
+    variables.id,
+  ]
+  const identifier = identifierCandidates.find(
+    (candidate) =>
+      typeof candidate === 'string' || typeof candidate === 'number'
+  )
+
+  return identifier === undefined
+    ? operationName
+    : `${operationName}:${String(identifier)}`
+}
+
 export const createClient = ({
   httpUri,
   wsUri,
   onNetworkError = () => undefined,
   extraLinks = [],
   cacheConfig,
+  requestLifecycle = createGraphQLRequestLifecycle(),
 }: {
   httpUri: string
   wsUri: string
   onNetworkError?: ErrorLink.ErrorHandler
   extraLinks?: Array<ApolloLink>
   cacheConfig: InMemoryCacheConfig
+  requestLifecycle?: GraphQLRequestLifecycle
 }): ApolloClient<NormalizedCacheObject> => {
   const httpLink = createHttpLink({ uri: httpUri })
+
+  const requestLifecycleLink = new ApolloLink((operation, forward) => {
+    if (requestLifecycle.isTerminated) {
+      return new Observable((observer) => {
+        observer.error(
+          new GraphQLRequestCancelledError(operation.operationName)
+        )
+      })
+    }
+
+    const controller = new AbortController()
+    const requestLifecyclePolicy: GraphQLRequestTeardownPolicy =
+      operation.getContext().requestLifecyclePolicy === 'settle'
+        ? 'settle'
+        : 'abort'
+    requestLifecycle.trackRequest(
+      controller,
+      requestLifecyclePolicy,
+      getOperationIdentity(operation.operationName, operation.variables)
+    )
+    let existingSignal: AbortSignal | undefined
+    let abortFromExistingSignal: (() => void) | undefined
+
+    operation.setContext(
+      ({ fetchOptions = {} }: { fetchOptions?: RequestInit }) => {
+        existingSignal = fetchOptions.signal ?? undefined
+        if (existingSignal) {
+          abortFromExistingSignal = () => {
+            controller.abort(existingSignal?.reason)
+          }
+          if (existingSignal.aborted) {
+            abortFromExistingSignal()
+          } else {
+            existingSignal.addEventListener('abort', abortFromExistingSignal, {
+              once: true,
+            })
+          }
+        }
+
+        return {
+          fetchOptions: {
+            ...fetchOptions,
+            signal: controller.signal,
+          },
+        }
+      }
+    )
+
+    const releaseRequest = (outcome: GraphQLRequestOutcome = 'succeeded') => {
+      if (existingSignal && abortFromExistingSignal) {
+        existingSignal.removeEventListener('abort', abortFromExistingSignal)
+      }
+      return requestLifecycle.releaseRequest(controller, outcome)
+    }
+
+    return new Observable((observer) => {
+      let hasGraphQLErrors = false
+      const subscription = forward(operation).subscribe({
+        next: (result) => {
+          hasGraphQLErrors =
+            hasGraphQLErrors || (result.errors?.length ?? 0) > 0
+          observer.next(result)
+        },
+        error: (error) => {
+          releaseRequest(
+            requestLifecyclePolicy === 'settle' ? 'failed' : 'succeeded'
+          )
+          observer.error(
+            isGraphQLRequestCancellation(error)
+              ? new GraphQLRequestCancelledError(operation.operationName)
+              : error
+          )
+        },
+        complete: () => {
+          releaseRequest(
+            requestLifecyclePolicy === 'settle' && hasGraphQLErrors
+              ? 'failed'
+              : 'succeeded'
+          )
+          observer.complete()
+        },
+      })
+
+      return () => {
+        if (requestLifecyclePolicy === 'settle') {
+          const requestWasActive = releaseRequest('failed')
+          if (requestWasActive && !controller.signal.aborted) {
+            controller.abort()
+          }
+        } else {
+          const requestWasActive = releaseRequest()
+          if (requestWasActive && !controller.signal.aborted) {
+            controller.abort()
+          }
+        }
+        subscription.unsubscribe()
+      }
+    })
+  })
 
   const retryLink = new RetryLink({
     delay: {
@@ -93,6 +491,9 @@ export const createClient = ({
     attempts: {
       max: 3,
       retryIf: (error) => {
+        if (isGraphQLRequestCancellation(error)) {
+          return false
+        }
         // Only retry on network errors, not GraphQL errors
         // Network errors indicate connectivity issues that might be transient
         return !!error && !error.result
@@ -101,6 +502,10 @@ export const createClient = ({
   })
 
   const errorHandlingLink = onError((response) => {
+    if (isGraphQLRequestCancellation(response.networkError)) {
+      return
+    }
+
     if (response.networkError) {
       onNetworkError(response)
     }
@@ -116,11 +521,16 @@ export const createClient = ({
         category: 'authentication',
         operation: operation.operationName,
       })
+      return new Observable((observer) => {
+        observer.error(
+          new GraphQLMissingAuthorizationError(operation.operationName)
+        )
+      })
     }
 
     operation.setContext({
       headers: {
-        authorization: accessToken ? `Bearer ${accessToken}` : '',
+        authorization: `Bearer ${accessToken}`,
       },
     })
     return forward(operation)
@@ -171,172 +581,178 @@ export const createClient = ({
       }, GRAPHQL_WS_KEEPALIVE_TIMEOUT_MS)
     }
 
-    return new GraphQLWsLink(
-      createWebsocketClient({
-        url: wsUri,
-        connectionParams: {
-          authToken: window.sessionStorage.getItem('accessToken'),
-        },
-        // Only open the socket when there is at least one active subscription
-        lazy: true,
-        connectionAckWaitTimeout: GRAPHQL_WS_CONNECTION_ACK_TIMEOUT_MS,
-        keepAlive: GRAPHQL_WS_KEEPALIVE_INTERVAL_MS,
-        // Retry forever with exponential backoff, but wait for online before retrying
-        retryAttempts: Infinity,
-        shouldRetry: (closeOrError) => {
-          // Do not retry on auth-related close codes
-          const closeCode = getCloseCode(closeOrError)
-          const retryRequested = closeCode !== 4401 && closeCode !== 4403
+    const websocketClient = createWebsocketClient({
+      url: wsUri,
+      connectionParams: () => ({
+        authToken: window.sessionStorage.getItem('accessToken'),
+      }),
+      // Only open the socket when there is at least one active subscription
+      lazy: true,
+      connectionAckWaitTimeout: GRAPHQL_WS_CONNECTION_ACK_TIMEOUT_MS,
+      keepAlive: GRAPHQL_WS_KEEPALIVE_INTERVAL_MS,
+      // Retry forever with exponential backoff, but wait for online before retrying
+      retryAttempts: Infinity,
+      shouldRetry: (closeOrError) => {
+        if (requestLifecycle.isTerminated) {
+          return false
+        }
 
+        // Do not retry on auth-related close codes
+        const closeCode = getCloseCode(closeOrError)
+        const retryRequested = closeCode !== 4401 && closeCode !== 4403
+
+        logger.info(
+          `GraphQL WebSocket retry ${retryRequested ? 'requested' : 'blocked'}`,
+          LogEvent.GRAPHQL_WS_RETRY_DECISION,
+          {
+            ws_url: wsUri,
+            retry_requested: retryRequested,
+            error_message: serializeError(closeOrError),
+            ...getCloseEventContext(closeOrError),
+          }
+        )
+
+        if (!retryRequested) {
+          return false
+        }
+
+        return true
+      },
+      retryWait: async (retries) => {
+        const wasOffline =
+          typeof window !== 'undefined' && !window.navigator.onLine
+        // Exponential backoff with jitter (cap at ~16s)
+        const base = Math.min(16000, 1000 * Math.pow(2, retries))
+        const jitter = Math.floor(Math.random() * 300)
+        const delay = base + jitter
+
+        logger.warn(
+          'GraphQL WebSocket retry scheduled',
+          LogEvent.GRAPHQL_WS_RETRY_WAIT,
+          {
+            ws_url: wsUri,
+            retry_attempt: retries,
+            retry_delay_ms: delay,
+            browser_online: !wasOffline,
+          }
+        )
+
+        // If offline, wait until the browser is back online first
+        if (wasOffline) {
+          await new Promise<void>((resolve) => {
+            const onOnline = () => {
+              window.removeEventListener('online', onOnline)
+              resolve()
+            }
+            window.addEventListener('online', onOnline)
+          })
+        }
+        await new Promise((r) => setTimeout(r, delay))
+      },
+      // WebSocket connection event logging. Keep payloads out of logs; frame types
+      // and socket state are enough to diagnose subscription lifecycle issues.
+      on: {
+        connecting: () => {
           logger.info(
-            `GraphQL WebSocket retry ${
-              retryRequested ? 'requested' : 'blocked'
-            }`,
-            LogEvent.GRAPHQL_WS_RETRY_DECISION,
+            'GraphQL WebSocket connecting',
+            LogEvent.GRAPHQL_WS_CONNECTING,
             {
               ws_url: wsUri,
-              retry_requested: retryRequested,
-              error_message: serializeError(closeOrError),
-              ...getCloseEventContext(closeOrError),
+              connection_ack_timeout_ms: GRAPHQL_WS_CONNECTION_ACK_TIMEOUT_MS,
+              keepalive_interval_ms: GRAPHQL_WS_KEEPALIVE_INTERVAL_MS,
+              keepalive_timeout_ms: GRAPHQL_WS_KEEPALIVE_TIMEOUT_MS,
+              browser_online:
+                typeof window !== 'undefined'
+                  ? window.navigator.onLine
+                  : undefined,
+              browser_visibility:
+                typeof document !== 'undefined'
+                  ? document.visibilityState
+                  : undefined,
             }
           )
-
-          if (!retryRequested) {
-            return false
-          }
-
-          return true
         },
-        retryWait: async (retries) => {
-          const wasOffline =
-            typeof window !== 'undefined' && !window.navigator.onLine
-          // Exponential backoff with jitter (cap at ~16s)
-          const base = Math.min(16000, 1000 * Math.pow(2, retries))
-          const jitter = Math.floor(Math.random() * 300)
-          const delay = base + jitter
-
-          logger.warn(
-            'GraphQL WebSocket retry scheduled',
-            LogEvent.GRAPHQL_WS_RETRY_WAIT,
+        opened: (socket) => {
+          activeSocket = socket as WebSocket
+          logger.info('GraphQL WebSocket opened', LogEvent.GRAPHQL_WS_OPENED, {
+            ws_url: wsUri,
+            ...getSocketContext(socket),
+          })
+        },
+        connected: (socket) => {
+          activeSocket = socket as WebSocket
+          logger.info(
+            'GraphQL WebSocket connected',
+            LogEvent.GRAPHQL_WS_CONNECTED,
             {
               ws_url: wsUri,
-              retry_attempt: retries,
-              retry_delay_ms: delay,
-              browser_online: !wasOffline,
+              ...getSocketContext(socket),
             }
           )
-
-          // If offline, wait until the browser is back online first
-          if (wasOffline) {
-            await new Promise<void>((resolve) => {
-              const onOnline = () => {
-                window.removeEventListener('online', onOnline)
-                resolve()
-              }
-              window.addEventListener('online', onOnline)
-            })
-          }
-          await new Promise((r) => setTimeout(r, delay))
         },
-        // WebSocket connection event logging. Keep payloads out of logs; frame types
-        // and socket state are enough to diagnose subscription lifecycle issues.
-        on: {
-          connecting: () => {
-            logger.info(
-              'GraphQL WebSocket connecting',
-              LogEvent.GRAPHQL_WS_CONNECTING,
-              {
-                ws_url: wsUri,
-                connection_ack_timeout_ms: GRAPHQL_WS_CONNECTION_ACK_TIMEOUT_MS,
-                keepalive_interval_ms: GRAPHQL_WS_KEEPALIVE_INTERVAL_MS,
-                keepalive_timeout_ms: GRAPHQL_WS_KEEPALIVE_TIMEOUT_MS,
-                browser_online:
-                  typeof window !== 'undefined'
-                    ? window.navigator.onLine
-                    : undefined,
-                browser_visibility:
-                  typeof document !== 'undefined'
-                    ? document.visibilityState
-                    : undefined,
-              }
-            )
-          },
-          opened: (socket) => {
-            activeSocket = socket as WebSocket
-            logger.info(
-              'GraphQL WebSocket opened',
-              LogEvent.GRAPHQL_WS_OPENED,
-              {
-                ws_url: wsUri,
-                ...getSocketContext(socket),
-              }
-            )
-          },
-          connected: (socket) => {
-            activeSocket = socket as WebSocket
-            logger.info(
-              'GraphQL WebSocket connected',
-              LogEvent.GRAPHQL_WS_CONNECTED,
-              {
-                ws_url: wsUri,
-                ...getSocketContext(socket),
-              }
-            )
-          },
-          ping: (received) => {
-            logger.info('GraphQL WebSocket ping', LogEvent.GRAPHQL_WS_PING, {
-              ws_url: wsUri,
-              ping_received: received,
-              ...getSocketContext(activeSocket),
-            })
+        ping: (received) => {
+          logger.info('GraphQL WebSocket ping', LogEvent.GRAPHQL_WS_PING, {
+            ws_url: wsUri,
+            ping_received: received,
+            ...getSocketContext(activeSocket),
+          })
 
-            if (!received) {
-              scheduleKeepAliveTimeout()
-            }
-          },
-          pong: (received) => {
-            logger.info('GraphQL WebSocket pong', LogEvent.GRAPHQL_WS_PONG, {
-              ws_url: wsUri,
-              pong_received: received,
-              ...getSocketContext(activeSocket),
-            })
+          if (!received) {
+            scheduleKeepAliveTimeout()
+          }
+        },
+        pong: (received) => {
+          logger.info('GraphQL WebSocket pong', LogEvent.GRAPHQL_WS_PONG, {
+            ws_url: wsUri,
+            pong_received: received,
+            ...getSocketContext(activeSocket),
+          })
 
-            if (received) {
-              clearKeepAliveTimeout()
-            }
-          },
-          message: (message) => {
-            logger.info(
-              'GraphQL WebSocket message received',
-              LogEvent.GRAPHQL_WS_MESSAGE,
-              {
-                ws_url: wsUri,
-                ...getMessageContext(message),
-              }
-            )
-          },
-          error: (error) => {
-            logger.error('GraphQL WebSocket error', LogEvent.GRAPHQL_WS_ERROR, {
-              ws_url: wsUri,
-              error_message: serializeError(error),
-              ...getCloseEventContext(error),
-            })
-          },
-          closed: (event) => {
+          if (received) {
             clearKeepAliveTimeout()
-            activeSocket = undefined
-            logger.warn(
-              'GraphQL WebSocket disconnected',
-              LogEvent.GRAPHQL_WS_DISCONNECTED,
-              {
-                ws_url: wsUri,
-                ...getCloseEventContext(event),
-              }
-            )
-          },
+          }
         },
-      })
-    )
+        message: (message) => {
+          logger.info(
+            'GraphQL WebSocket message received',
+            LogEvent.GRAPHQL_WS_MESSAGE,
+            {
+              ws_url: wsUri,
+              ...getMessageContext(message),
+            }
+          )
+        },
+        error: (error) => {
+          if (requestLifecycle.isTerminated) {
+            return
+          }
+          logger.error('GraphQL WebSocket error', LogEvent.GRAPHQL_WS_ERROR, {
+            ws_url: wsUri,
+            error_message: serializeError(error),
+            ...getCloseEventContext(error),
+          })
+        },
+        closed: (event) => {
+          clearKeepAliveTimeout()
+          activeSocket = undefined
+          if (requestLifecycle.isTerminated) {
+            return
+          }
+          logger.warn(
+            'GraphQL WebSocket disconnected',
+            LogEvent.GRAPHQL_WS_DISCONNECTED,
+            {
+              ws_url: wsUri,
+              ...getCloseEventContext(event),
+            }
+          )
+        },
+      },
+    })
+
+    requestLifecycle.trackWebSocketClient(websocketClient)
+
+    return new GraphQLWsLink(websocketClient)
   }
   const wsLink = createWsLink()
 
@@ -350,13 +766,32 @@ export const createClient = ({
 
   const defaultLink = ApolloLink.from([
     authenticationLink,
+    requestLifecycleLink,
     ...extraLinks,
     retryLink,
     errorHandlingLink,
     httpLink,
   ])
 
-  const link = wsLink ? split(isSubscription, wsLink, defaultLink) : defaultLink
+  const guardedWsLink = wsLink
+    ? ApolloLink.from([
+        new ApolloLink((operation, forward) => {
+          if (requestLifecycle.isTerminated) {
+            return new Observable((observer) => {
+              observer.error(
+                new GraphQLRequestCancelledError(operation.operationName)
+              )
+            })
+          }
+          return forward(operation)
+        }),
+        wsLink,
+      ])
+    : null
+
+  const link = guardedWsLink
+    ? split(isSubscription, guardedWsLink, defaultLink)
+    : defaultLink
 
   return new ApolloClient({
     ssrMode: typeof window === 'undefined',

--- a/src/services/graphql/finalizeTerminalGraphQLRequests.ts
+++ b/src/services/graphql/finalizeTerminalGraphQLRequests.ts
@@ -1,0 +1,28 @@
+import type {
+  GraphQLRequestLifecycle,
+  GraphQLSettlingResult,
+} from './apollo-client'
+
+export const finalizeTerminalGraphQLRequests = async ({
+  requestLifecycle,
+  clearAccessToken,
+  isCurrent = () => true,
+}: {
+  requestLifecycle: GraphQLRequestLifecycle
+  clearAccessToken: () => void
+  isCurrent?: () => boolean
+}): Promise<GraphQLSettlingResult> => {
+  const result = await requestLifecycle.waitForSettlingRequests()
+
+  if (result.status === 'timed-out') {
+    requestLifecycle.cancelPendingRequests({ abortSettling: true })
+  }
+
+  // A finalization started by an unmounted or superseded session must not
+  // clear credentials installed for the next session.
+  if (isCurrent()) {
+    clearAccessToken()
+  }
+
+  return result
+}

--- a/src/services/graphql/index.ts
+++ b/src/services/graphql/index.ts
@@ -1,2 +1,4 @@
 export * from './apollo-client'
 export * from './createApolloCacheUpdate'
+export * from './finalizeTerminalGraphQLRequests'
+export * from './GraphQLRequestLifecycleContext'


### PR DESCRIPTION
###  Problem
When a hosted session expired or completed, the frontend could clear its access token while polling, form evaluation, submission, uploads, or subscriptions were still active.
Those operations could then retry or restart without authentication, resulting in:
- tokenless GraphQL requests;
- misleading network/500 error screens after expiry;
- unnecessary Sentry errors;
- patient writes being interrupted during session completion.

This MR introduces an ordered, idempotent teardown for terminal hosted sessions. The separate backend stale-job issue is outside the scope of this change.

### What changed
**GraphQL request lifecycle**

Added a request lifecycle scoped to each Apollo client which:
- tracks active HTTP requests using `AbortController`;
- distinguishes abortable reads from patient writes that should be allowed to settle;
- aborts polling, queries, retries, and other non-settling requests on termination;
- allows active submissions and uploads to finish before authentication is cleared;
- applies a 10-second grace period before aborting a stuck write;
- prevents any new HTTP or WebSocket operation after teardown starts;
- disposes active GraphQL WebSocket clients and prevents reconnection;
- avoids retrying or reporting intentional cancellation as a network error;
- blocks missing-token requests locally instead of sending `authorization: ""`.

Historical write failures are not carried into later terminal teardown. Only writes that were active when termination started can block finalization.
Concurrent file uploads receive unique lifecycle identities, so one upload cannot incorrectly supersede or abort another.
**Terminal session handling**
Hosted-session completion and expiry now use a centralized, idempotent transition which:
1. marks the session as terminal;
2. stops session polling;
3. blocks new operations;
4. aborts safe-to-cancel requests and subscriptions;
5. waits for active patient writes to settle;
6. clears authentication;
7. redirects or renders the terminal page.

If a patient write fails or exceeds the grace period, the user receives a safe completion error instead of silently losing the write.

Terminal session state now takes precedence over stale network and invalid-session errors, preventing expiry from being replaced by a misleading error screen.

**Request producer guards**
Request-producing hooks and components now verify that the session is active before starting work:
- hosted-session and activity polling;
- checklist and form submission;
- form rule evaluation;
- message reads;
- extension activity completion;
- session completion;
- file upload and signed URL retrieval;
- activity and extension-detail queries.

Debounced form-rule evaluation is cancelled when a session becomes terminal, and polling cleanup explicitly stops Apollo polling.
**Authentication and session isolation**
Authentication handling was hardened to:
- validate authentication responses before accepting a token;
- fail recoverably instead of showing an indefinite loader;
- time out stalled authentication requests;
- prevent stale responses from one session installing credentials for another;
- prevent an intentionally cleared token from being reinstalled;
- synchronously block the previous session tree during navigation;
- remount Apollo with a fresh cache and request lifecycle for a new session;
- keep React state synchronized when the stored token is removed.

Session initialization now runs inside the application error boundary so malformed session or branding data renders the safe error page instead of crashing the application.

**Why this matters**
The frontend now treats session expiry as a coordinated lifecycle transition rather than simply deleting the token.
This prevents post-expiry tokenless requests and misleading error UX while preserving active patient writes and isolating credentials, caches, and requests between hosted sessions.
