### PR TITLE
fix: deliver terminal session status when a poll is aborted mid-completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ✅ CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - staging
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Typecheck, lint and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Typecheck
+        run: yarn tsc --noEmit
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Test
+        run: yarn test

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,13 +1,18 @@
 const path = require('path')
 
+const toRelative = (filenames) =>
+  filenames.map((f) => path.relative(process.cwd(), f))
+
 const buildEslintCommand = (filenames) =>
-  `next lint --fix --file ${filenames
-    .map((f) => path.relative(process.cwd(), f))
-    .join(' --file ')}`
+  `next lint --fix --file ${toRelative(filenames).join(' --file ')}`
+
+// Only the tests reachable from the staged files, so the hook stays fast.
+const buildTestCommand = (filenames) =>
+  `vitest related --run --passWithNoTests ${toRelative(filenames).join(' ')}`
 
 module.exports = {
   // Type check TypeScript files
-  '**/*.(ts|tsx)': () => 'yarn tsc --noEmit',
+  '**/*.(ts|tsx)': [() => 'yarn tsc --noEmit', buildTestCommand],
   '*.{js,jsx,ts,tsx}': [buildEslintCommand],
   // Format MarkDown and JSON
   '**/*.(md|json)': (filenames) =>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,190 @@
+# hosted-pages
+
+Next.js 14 (pages router) app that renders an Awell **hosted session**: the patient- or
+clinician-facing page reached via `https://goto.<region>.awell.health/?sessionId=…`. It walks the
+stakeholder through the session's activities (messages, forms, checklists, extensions) and then
+redirects to the integrator's `success_url` / `cancel_url`.
+
+State comes from the orchestration GraphQL API over both HTTP (queries/mutations) and a
+`graphql-ws` websocket (subscriptions).
+
+## Commands
+
+```bash
+yarn dev              # local dev server
+yarn test             # vitest run (jsdom + React Testing Library)
+yarn test:watch
+yarn tsc --noEmit     # typecheck
+yarn lint             # next lint (eslint + prettier)
+yarn pre-commit       # typecheck + lint + test
+yarn codegen          # regenerate src/types/generated/** from ../awell-next schema
+```
+
+`codegen.yml` reads the schema from a **sibling checkout** (`../awell-next/packages/pathway-orchestration/orchestration-schema.graphql`). Codegen fails without it; the generated files are committed, so you rarely need to run it.
+
+Commits run `lint-staged` (typecheck + eslint + `vitest related`) via husky. CI (`.github/workflows/ci.yml`) runs typecheck, lint and the full test suite on every PR.
+
+---
+
+## Session state: two independent paths
+
+Session status reaches the UI two ways. They look redundant. **They are not.**
+
+| Path     | Mechanism                                                                                                                           | Where                                                                            |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **Poll** | `useGetHostedSessionQuery` + Apollo `startPolling(2000)`, registered through `ConnectivityContext` so it pauses when offline/hidden | `pages/index.tsx` (polling registration), `src/contexts/ConnectivityContext.tsx` |
+| **Push** | `useOnHostedSessionCompletedSubscription` / `…ExpiredSubscription` → `client.writeQuery`                                            | `src/hooks/useHostedSession/useHostedSession.ts`                                 |
+
+The push path only writes to the Apollo **cache**. The page reads the session exclusively from the
+value `useHostedSession()` returns. So whenever the query observable is wedged, the push path is
+powerless even though the browser already has the answer.
+
+> **Invariant: a terminal session status, once known from any source, must reach the page.**
+> Never let query transport state (`loading`, `error`, cancellation, or a stale delivered result)
+> suppress an already-known terminal status.
+
+`useHostedSession` therefore keeps the terminal session in React state (`terminalSession`) and
+prefers it over `data?.hostedSession?.session` whenever the query is still reporting a
+non-terminal status. Don't "simplify" that back to reading `data` alone — see the deadlock below.
+
+`useSessionActivities` is the pattern to copy for new hooks: it returns `activities` and `loading`
+side by side, never early-returns, and merges subscription data with Apollo's own `subscribeToMore`
+rather than a manual `writeQuery`.
+
+## `cancelPendingRequests()` is a one-way door
+
+`createGraphQLRequestLifecycle()` (`src/services/graphql/apollo-client.ts`) tracks every in-flight
+request. `cancelPendingRequests()` sets `isTerminated = true` **forever** — it is never reset — and:
+
+- aborts every request tracked with the `abort` policy,
+- disposes the websocket clients,
+- causes `requestLifecycleLink` to reject all _future_ operations with `GraphQLRequestCancelledError`.
+
+This is intentional: it stops doomed writes against a dead session (`2d6c3b5 fix: safely tear down expired session requests (#435)`). Consequences to internalise:
+
+- **Treat it as process teardown, not a retryable action.** Anything the UI still needs must
+  already be in the cache — and reachable without a new request — before you call it.
+- Any state machine that waits on a future request will hang. `RetryLink` will not save you:
+  `retryIf` deliberately returns `false` for cancellations.
+- Requests that must _not_ be killed mid-flight (patient-data writes) opt into the `settle` policy
+  via `context.requestLifecyclePolicy = 'settle'`, and `finalizeTerminalGraphQLRequests` waits for
+  them (`waitForSettlingRequests`) before credentials are cleared and the redirect fires.
+
+### The deadlock this cost us once (fixed — keep it fixed)
+
+Reference failure: Checkly `[production-us] app-hosted-pages - walkthrough`, 2026-08-03 09:14 UTC,
+session `GpQ2OeoFxwm9`. The backend was blameless — orchestration published `sessionCompleted`
+22 ms after completing the session.
+
+1. The frame arrived **while a `GetHostedSession` poll was in flight**.
+2. `handleTerminalSession` → `cancelPendingRequests()` aborted that poll.
+3. Apollo parked the observable on the cancellation (`networkStatus: 8` / `error`) and kept serving
+   the **last pre-completion snapshot**. `loading` was `false`; `error` was suppressed by the
+   existing `isGraphQLRequestCancellation` guard.
+4. `isTerminated` blocked every subsequent request, so nothing ever reconciled the observable with
+   the cache — which _did_ hold `COMPLETED`. The Playwright trace shows **zero requests** for the
+   remaining 27 s.
+5. The hook returned `status: ACTIVE` forever → `shouldRedirect` stayed `false` → no redirect, and
+   `ActivityProvider` kept polling for an activity that would never come, rendering the skeleton.
+
+Note what this was _not_: not a `loading: true` hang, and not the `LoadingPage` in `pages/index.tsx`.
+Apollo also **suppresses cache-driven notifications while a request is in flight** (`QueryInfo.shouldNotify`
+returns false for `cache-first`), so writing to the cache before teardown is necessary but not
+sufficient on its own.
+
+Regression tests: `src/hooks/useHostedSession/useHostedSession.test.tsx`.
+
+## Rendering precedence
+
+`pages/index.tsx` checks these in order — an earlier branch masks every later one:
+
+1. `terminalWriteError` → `ErrorPage` (patient writes could not be finalised)
+2. `!isSessionTerminal && hasNetworkError && networkErrorCount >= 3` → `NetworkErrorGate`
+3. `!isSessionTerminal && showInvalidSession` → `InvalidSessionGate`
+4. `sessionLoading` → `<LoadingPage showLogoBox={true} />`
+5. otherwise → `SessionRouter` (switches on `session.status`), plus `ErrorPage` when `error` is set
+
+**There are two different skeletons.** Inside `SessionRouter`'s `Active` branch,
+`ActivitiesContainer` renders its own `<LoadingPage />` (no logo box) from two places:
+
+- `ActivityProvider` while the activities query is loading, and
+- `Activities` while `state === 'polling' | 'polling-extended'` — i.e. no active activity yet.
+
+A screenshot of "logo + three grey bars" is ambiguous between (4) and the `Activities` one, because
+`HostedPageLayout` draws the logo in either case. Check whether `session.status` is `ACTIVE` before
+concluding which. In the reference failure it was the `Activities` one.
+
+An aborted request produces **none** of the error states above — no error UI, and the network-error
+gate never trips. That silence is the signature, not the absence of a problem.
+
+## Observability
+
+Conventions (never log during render, always `Sentry.logger?.` with optional chaining, always
+include error details) live in `.cursor/rules/observability-best-practices.mdc` — follow it; it is
+not duplicated here. Use `logger` from `src/utils/logging.ts` with a `LogEvent`, which also attaches
+session context from `sessionStorage['log-context']`.
+
+Events worth knowing when debugging a stuck session:
+
+| `LogEvent`                                       | Meaning                                                                                                                |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `GRAPHQL_REQUESTS_ABORTED`                       | `cancelPendingRequests()` aborted N in-flight requests, with operation names. The client goes silent right after this. |
+| `SESSION_TERMINAL_STATUS_DIVERGED`               | The push path knows the session ended but the query still reports an older status — the deadlock's fingerprint.        |
+| `SESSION_QUERY_STALLED`                          | `useGetHostedSessionQuery` stayed loading past ~3 poll intervals: wedged, not slow.                                    |
+| `SESSION_START_POLLING` / `SESSION_STOP_POLLING` | Polling lifecycle, incl. connectivity-driven pauses.                                                                   |
+| `GRAPHQL_WS_*`                                   | Websocket connect/retry/keepalive.                                                                                     |
+
+## Branch topology
+
+Work lands on `main`, then flows out via merge commits:
+
+```
+main → staging → production / production-us / production-uk / sandbox
+```
+
+`.github/workflows/*-deployment.yml` do the merges (`production-deployment.yml` can also hotfix
+straight from `main`). Verified as of 2026-08-03:
+
+- `main` **is** an ancestor of every deploy branch; no deploy branch is an ancestor of `main`.
+- App code (`src/`, `pages/`, `lib/`) is currently **byte-identical** across `main`, `staging`,
+  `production`, `production-us`, `production-uk`.
+
+So a Sentry `release` SHA points at a merge commit that does **not** exist on `main`, even when the
+file contents match exactly. Confirm which branch you are reasoning about — and prefer diffing
+paths (`git diff main origin/production -- src pages`) over comparing SHAs — before concluding
+"the code doesn't do that".
+
+## Diagnosing a red Checkly check
+
+The Checkly CLI is the fastest path from a red check to root cause (`npx checkly whoami` to confirm
+you are on the **Awell** account):
+
+```bash
+npx checkly checks get <check-id> --result <result-id> --output json
+npx checkly assets list     --check-id <check-id> --result-id <result-id>
+npx checkly assets download --check-id <check-id> --result-id <result-id> --dir ./tmp
+# unzip assets.zip, then unzip traces/*.zip
+#   1-trace.network → every request with operationName + status (-1 == aborted)
+#   1-trace.trace   → screencast-frame entries are timestamped JPEGs in resources/
+```
+
+**Fingerprint of a client-side abort:** a request with `status -1` followed by _no further
+requests at all_. That is `cancelPendingRequests()`, not a network problem — and it leaves no error
+UI, so the page just sits there. Cross-check against `GRAPHQL_REQUESTS_ABORTED` in Sentry logs.
+
+## Testing
+
+Vitest + React Testing Library, jsdom, config in `vitest.config.ts`, globals set up in
+`test/setup.ts` (session storage token + `TEST_DISABLE_SUBSCRIPTIONS`). Tests live next to the code
+as `*.test.ts(x)`.
+
+`test/hostedSessionHarness.tsx` mounts `HostedSessionProvider` against the **real** `createClient`
+link chain, deliberately _not_ `MockedProvider` — the bugs in this area live in the interaction
+between the request lifecycle links, `AbortController` and Apollo's polling observable, which
+`MockedProvider` replaces wholesale. It gives you:
+
+- `fetchController` — every GraphQL request stays in flight until you resolve/fail it, so "a poll is
+  in flight right now" is deterministic; aborts reject with a real `AbortError`.
+- `subscriptionController.emit('OnHostedSessionCompleted', …)` — push frames on demand.
+- `readCachedStatus()` / `current()` — assert cache and hook state separately, which is exactly the
+  distinction that matters for the invariant above.

--- a/package.json
+++ b/package.json
@@ -9,15 +9,17 @@
     "i18n:up": "localazy upload",
     "i18n:down": "localazy download",
     "lint": "next lint",
-    "pre-commit": "yarn tsc --noEmit && next lint",
+    "pre-commit": "yarn tsc --noEmit && next lint && yarn test",
     "prepare": "husky install",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@apollo/client": "^3.8.6",
+    "@awell-health/design-system": "0.16.2",
     "@awell-health/sol-scheduling": "0.5.0",
     "@awell-health/ui-library": "0.1.152",
-    "@awell-health/design-system": "0.16.2",
     "@formsort/react-embed": "^3.1.1",
     "@google-cloud/logging": "^11.0.0",
     "@localazy/cli": "^1.7.5",
@@ -55,6 +57,7 @@
     "@graphql-codegen/typescript-react-apollo": "^3.3.2",
     "@graphql-tools/mock": "^9.0.0",
     "@graphql-tools/schema": "^10.0.0",
+    "@testing-library/react": "^14.3.1",
     "@types/he": "^1.2.0",
     "@types/hellosign-embedded": "^2.0.2",
     "@types/jsonwebtoken": "^8.5.8",
@@ -72,7 +75,8 @@
     "jsdom": "^22.1.0",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
-    "typescript": "4.7.4"
+    "typescript": "4.7.4",
+    "vitest": "^1.6.1"
   },
   "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca",
   "resolutions": {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,7 +31,10 @@ import { SuccessPage } from '../src/components/SuccessPage'
 import { AWELL_BRAND_COLOR } from '../src/config'
 import { useConnectivity } from '../src/contexts/ConnectivityContext'
 import { useNetworkError } from '../src/contexts/NetworkErrorContext'
-import { useHostedSession } from '../src/hooks/useHostedSession'
+import {
+  shouldRedirectAfterSession,
+  useHostedSession,
+} from '../src/hooks/useHostedSession'
 import { HostedSession } from '../src/hooks/useHostedSession/types'
 import { HostedSessionLayout } from '../src/layouts'
 import { useAuthentication } from '../src/services/authentication'
@@ -437,15 +440,10 @@ function useRedirectAfterSession(params: {
   const { setLogoOverride, router, session } = params
   const timeoutIdsRef = useRef<number[]>([])
 
-  const shouldRedirect = useMemo(() => {
-    const hasSuccess =
-      session?.status === HostedSessionStatus.Completed &&
-      !isNil(session?.success_url)
-    const hasCancel =
-      session?.status === HostedSessionStatus.Expired &&
-      !isNil(session?.cancel_url)
-    return hasSuccess || hasCancel
-  }, [session])
+  const shouldRedirect = useMemo(
+    () => shouldRedirectAfterSession(session),
+    [session]
+  )
 
   const clearAllTimeouts = useCallback(() => {
     timeoutIdsRef.current.forEach((id) => clearTimeout(id))

--- a/src/hooks/useHostedSession/index.ts
+++ b/src/hooks/useHostedSession/index.ts
@@ -1,2 +1,7 @@
 export { HostedSessionProvider, useHostedSession } from './useHostedSession'
 export type { UseHostedSessionHook } from './useHostedSession'
+export {
+  getSessionRedirectUrl,
+  isTerminalSessionStatus,
+  shouldRedirectAfterSession,
+} from './terminalSession'

--- a/src/hooks/useHostedSession/terminalSession.test.ts
+++ b/src/hooks/useHostedSession/terminalSession.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { HostedSessionStatus } from '../../types/generated/types-orchestration'
+import type { HostedSession } from './types'
+import {
+  getSessionRedirectUrl,
+  isTerminalSessionStatus,
+  shouldRedirectAfterSession,
+} from './terminalSession'
+
+const session = (overrides: Partial<HostedSession>): HostedSession =>
+  ({
+    id: 'session-1',
+    pathway_id: 'pathway-1',
+    status: HostedSessionStatus.Active,
+    success_url: 'https://success.example',
+    cancel_url: 'https://cancel.example',
+    organization_slug: 'awell-dev',
+    stakeholder: { id: 's1', type: 'PATIENT', name: 'Test' },
+    ...overrides,
+  } as HostedSession)
+
+describe('isTerminalSessionStatus', () => {
+  it.each([
+    [HostedSessionStatus.Completed, true],
+    [HostedSessionStatus.Expired, true],
+    [HostedSessionStatus.Active, false],
+    [undefined, false],
+  ])('%s → %s', (status, expected) => {
+    expect(isTerminalSessionStatus(status)).toBe(expected)
+  })
+})
+
+describe('getSessionRedirectUrl', () => {
+  it('sends a completed session to success_url', () => {
+    expect(
+      getSessionRedirectUrl(session({ status: HostedSessionStatus.Completed }))
+    ).toBe('https://success.example')
+  })
+
+  it('sends an expired session to cancel_url', () => {
+    expect(
+      getSessionRedirectUrl(session({ status: HostedSessionStatus.Expired }))
+    ).toBe('https://cancel.example')
+  })
+
+  it('has no destination for an active session', () => {
+    expect(getSessionRedirectUrl(session({}))).toBeUndefined()
+  })
+
+  it('has no destination when the integrator supplied no url', () => {
+    expect(
+      getSessionRedirectUrl(
+        session({ status: HostedSessionStatus.Completed, success_url: null })
+      )
+    ).toBeUndefined()
+  })
+
+  it('has no destination without a session', () => {
+    expect(getSessionRedirectUrl(undefined)).toBeUndefined()
+  })
+})
+
+describe('shouldRedirectAfterSession', () => {
+  it('is true only for a terminal session with a destination', () => {
+    expect(
+      shouldRedirectAfterSession(
+        session({ status: HostedSessionStatus.Completed })
+      )
+    ).toBe(true)
+    expect(
+      shouldRedirectAfterSession(
+        session({ status: HostedSessionStatus.Completed, success_url: null })
+      )
+    ).toBe(false)
+    expect(shouldRedirectAfterSession(session({}))).toBe(false)
+    expect(shouldRedirectAfterSession(undefined)).toBe(false)
+  })
+})

--- a/src/hooks/useHostedSession/terminalSession.ts
+++ b/src/hooks/useHostedSession/terminalSession.ts
@@ -1,0 +1,40 @@
+import { isNil } from 'lodash'
+import { HostedSessionStatus } from '../../types/generated/types-orchestration'
+import type { HostedSession } from './types'
+
+/**
+ * A session status from which the session can never leave. Terminal statuses are
+ * special throughout the app: they stop polling, close the Apollo client to new
+ * requests, and trigger the redirect back to the integrator.
+ */
+export const isTerminalSessionStatus = (
+  status: HostedSessionStatus | undefined
+): boolean =>
+  status === HostedSessionStatus.Completed ||
+  status === HostedSessionStatus.Expired
+
+/**
+ * The URL the patient is sent to once the session reaches a terminal status, or
+ * `undefined` when the session is not terminal or the integrator did not provide
+ * one (in which case the terminal page is shown without redirecting).
+ */
+export const getSessionRedirectUrl = (
+  session: HostedSession | undefined
+): string | undefined => {
+  if (session?.status === HostedSessionStatus.Completed) {
+    return isNil(session.success_url) ? undefined : session.success_url
+  }
+  if (session?.status === HostedSessionStatus.Expired) {
+    return isNil(session.cancel_url) ? undefined : session.cancel_url
+  }
+  return undefined
+}
+
+/**
+ * Whether the page should redirect away from hosted pages for this session.
+ * Extracted from pages/index.tsx so the redirect condition can be asserted in
+ * tests against the same predicate production uses.
+ */
+export const shouldRedirectAfterSession = (
+  session: HostedSession | undefined
+): boolean => !isNil(getSessionRedirectUrl(session))

--- a/src/hooks/useHostedSession/useHostedSession.test.tsx
+++ b/src/hooks/useHostedSession/useHostedSession.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Regression tests for the session-completion deadlock.
+ *
+ * Failure being pinned down (Checkly `[production-us] app-hosted-pages -
+ * walkthrough`, session GpQ2OeoFxwm9, 2026-08-03 09:14 UTC): the
+ * `sessionCompleted` websocket frame landed while a `GetHostedSession` poll was
+ * in flight. `handleTerminalSession` aborted that poll, Apollo parked the query
+ * observable on the cancellation, and — because `isTerminated` blocks every
+ * later request — the hook served the pre-completion ACTIVE session forever.
+ * `shouldRedirect` stayed false, so hosted pages never redirected to
+ * `success_url` and the page sat on the activities skeleton.
+ */
+import { act, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  buildHostedSessionQueryData,
+  buildSession,
+  CANCEL_URL,
+  renderHostedSession,
+  SESSION_ID,
+  SUCCESS_URL,
+} from '../../../test/hostedSessionHarness'
+import { HostedSessionStatus } from '../../types/generated/types-orchestration'
+import { shouldRedirectAfterSession } from './terminalSession'
+
+const POLL_INTERVAL_MS = 20
+
+/** Mounts the hook and drives it to a polling ACTIVE session, as the walkthrough does. */
+const arrangeActiveSessionWithPollInFlight = async () => {
+  const harness = renderHostedSession()
+  const { fetchController } = harness
+
+  await waitFor(() =>
+    expect(fetchController.pendingFor('GetHostedSession')).toHaveLength(1)
+  )
+  await act(async () => {
+    fetchController.pendingFor('GetHostedSession')[0].resolve({
+      data: buildHostedSessionQueryData(HostedSessionStatus.Active),
+    })
+  })
+  await waitFor(() =>
+    expect(harness.current().session?.status).toBe(HostedSessionStatus.Active)
+  )
+
+  // pages/index.tsx registers this poll for as long as the session is active.
+  act(() => {
+    harness.current().startPolling(POLL_INTERVAL_MS)
+  })
+
+  // The harness never settles a request on its own, so once a poll has been
+  // issued it is deterministically in flight.
+  await waitFor(() =>
+    expect(
+      fetchController.pendingFor('GetHostedSession').length
+    ).toBeGreaterThan(0)
+  )
+
+  return {
+    harness,
+    inFlightPoll: fetchController.pendingFor('GetHostedSession')[0],
+  }
+}
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe('useHostedSession — terminal frame arrives while a poll is in flight', () => {
+  it('surfaces the completed session and redirects even though the poll was aborted', async () => {
+    const { harness, inFlightPoll } =
+      await arrangeActiveSessionWithPollInFlight()
+
+    await act(async () => {
+      harness.subscriptionController.emit('OnHostedSessionCompleted', {
+        sessionCompleted: buildSession(HostedSessionStatus.Completed),
+      })
+    })
+    await flush()
+
+    // Preconditions: this is genuinely the deadlock scenario, not a happy path.
+    expect(inFlightPoll.isAborted()).toBe(true)
+    expect(harness.requestLifecycle.isTerminated).toBe(true)
+
+    const result = harness.current()
+    expect(result.loading).toBe(false)
+    expect(result.error).toBeUndefined()
+    expect(result.session?.status).toBe(HostedSessionStatus.Completed)
+    expect(result.session?.id).toBe(SESSION_ID)
+    expect(result.session?.success_url).toBe(SUCCESS_URL)
+
+    // The condition pages/index.tsx uses to fire redirectAfterSession().
+    expect(shouldRedirectAfterSession(result.session)).toBe(true)
+  })
+
+  it('does not issue further requests once the session is terminal', async () => {
+    const { harness } = await arrangeActiveSessionWithPollInFlight()
+    const requestsBefore = harness.fetchController.requests.length
+
+    await act(async () => {
+      harness.subscriptionController.emit('OnHostedSessionCompleted', {
+        sessionCompleted: buildSession(HostedSessionStatus.Completed),
+      })
+    })
+    await flush()
+
+    // Teardown is a one-way door by design; the fix must not reopen it.
+    expect(harness.fetchController.requests.length).toBe(requestsBefore)
+    expect(harness.current().session?.status).toBe(
+      HostedSessionStatus.Completed
+    )
+  })
+
+  it('surfaces an expired session and redirects to cancel_url', async () => {
+    const { harness, inFlightPoll } =
+      await arrangeActiveSessionWithPollInFlight()
+
+    await act(async () => {
+      harness.subscriptionController.emit('OnHostedSessionExpired', {
+        sessionExpired: buildSession(HostedSessionStatus.Expired),
+      })
+    })
+    await flush()
+
+    expect(inFlightPoll.isAborted()).toBe(true)
+
+    const result = harness.current()
+    expect(result.loading).toBe(false)
+    expect(result.session?.status).toBe(HostedSessionStatus.Expired)
+    expect(result.session?.cancel_url).toBe(CANCEL_URL)
+    expect(shouldRedirectAfterSession(result.session)).toBe(true)
+  })
+
+  it('keeps branding and theme from the query after the poll is aborted', async () => {
+    const { harness } = await arrangeActiveSessionWithPollInFlight()
+
+    await act(async () => {
+      harness.subscriptionController.emit('OnHostedSessionCompleted', {
+        sessionCompleted: buildSession(HostedSessionStatus.Completed),
+      })
+    })
+    await flush()
+
+    const result = harness.current()
+    expect(result.branding?.accent_color).toBe('#004ac2')
+    expect(result.theme).toBeDefined()
+  })
+
+  it('writes the terminal session to the cache before teardown closes the client', async () => {
+    const { harness } = await arrangeActiveSessionWithPollInFlight()
+
+    await act(async () => {
+      harness.subscriptionController.emit('OnHostedSessionCompleted', {
+        sessionCompleted: buildSession(HostedSessionStatus.Completed),
+      })
+    })
+    await flush()
+
+    expect(harness.readCachedStatus()).toBe(HostedSessionStatus.Completed)
+  })
+})
+
+describe('useHostedSession — happy paths must be unaffected', () => {
+  it('reports loading until the initial query resolves', async () => {
+    const harness = renderHostedSession()
+
+    expect(harness.current().loading).toBe(true)
+    expect(harness.current().session).toBeUndefined()
+
+    await waitFor(() =>
+      expect(
+        harness.fetchController.pendingFor('GetHostedSession')
+      ).toHaveLength(1)
+    )
+    await act(async () => {
+      harness.fetchController.pendingFor('GetHostedSession')[0].resolve({
+        data: buildHostedSessionQueryData(HostedSessionStatus.Active),
+      })
+    })
+
+    await waitFor(() => expect(harness.current().loading).toBe(false))
+    expect(harness.current().session?.status).toBe(HostedSessionStatus.Active)
+    expect(shouldRedirectAfterSession(harness.current().session)).toBe(false)
+  })
+
+  it('completes via the poll path when no subscription frame arrives', async () => {
+    const { harness, inFlightPoll } =
+      await arrangeActiveSessionWithPollInFlight()
+
+    // The poll itself returns COMPLETED — the ordinary case, no abort involved.
+    await act(async () => {
+      inFlightPoll.resolve({
+        data: buildHostedSessionQueryData(HostedSessionStatus.Completed),
+      })
+    })
+    await flush()
+
+    await waitFor(() =>
+      expect(harness.current().session?.status).toBe(
+        HostedSessionStatus.Completed
+      )
+    )
+    expect(harness.current().loading).toBe(false)
+    expect(shouldRedirectAfterSession(harness.current().session)).toBe(true)
+    expect(harness.requestLifecycle.isTerminated).toBe(true)
+  })
+})

--- a/src/hooks/useHostedSession/useHostedSession.ts
+++ b/src/hooks/useHostedSession/useHostedSession.ts
@@ -20,11 +20,10 @@ import {
   useGraphQLRequestLifecycle,
 } from '../../services/graphql'
 import { Maybe } from '../../types'
-import {
-  HostedSessionStatus,
-  SessionMetadata,
-} from '../../types/generated/types-orchestration'
+import { SessionMetadata } from '../../types/generated/types-orchestration'
+import { LogEvent, logger } from '../../utils/logging'
 import { type CustomTheme, getTheme } from './branding'
+import { isTerminalSessionStatus } from './terminalSession'
 import type { HostedSession } from './types'
 import {
   BrandingSettings,
@@ -46,11 +45,9 @@ const getOrganizationsWithAutoReplay = (): string[] => {
     .filter(Boolean)
 }
 
-const isTerminalSessionStatus = (
-  status: HostedSessionStatus | undefined
-): boolean =>
-  status === HostedSessionStatus.Completed ||
-  status === HostedSessionStatus.Expired
+// Three 2s poll intervals (see the polling registration in pages/index.tsx).
+// Past this point the query observable is not slow, it is stuck.
+const STALLED_SESSION_QUERY_MS = 6000
 
 export interface UseHostedSessionHook {
   loading: boolean
@@ -72,6 +69,10 @@ const useHostedSessionValue = (): UseHostedSessionHook => {
   const defaultTheme = getTheme()
 
   const [isSessionCompleted, setIsSessionCompleted] = useState(false)
+  // The terminal session is held in React state so the page never depends on the
+  // query observable resolving to learn that the session ended. See the comment
+  // on the resolved `session` below.
+  const [terminalSession, setTerminalSession] = useState<HostedSession>()
   const handledTerminalSessionRef = useRef<string | undefined>()
   const stopPollingRef = useRef<() => void>(() => undefined)
   const requestLifecycle = useGraphQLRequestLifecycle()
@@ -87,6 +88,9 @@ const useHostedSessionValue = (): UseHostedSessionHook => {
     }
 
     handledTerminalSessionRef.current = terminalSessionKey
+    // Capture the payload before tearing anything down. `cancelPendingRequests()`
+    // is a one-way door: after it, no request can ever deliver this status again.
+    setTerminalSession(updatedHostedSession)
     setIsSessionCompleted(true)
     stopPollingRef.current()
     requestLifecycle.cancelPendingRequests()
@@ -112,8 +116,11 @@ const useHostedSessionValue = (): UseHostedSessionHook => {
   }: {
     updatedHostedSession: HostedSession
   }) => {
-    handleTerminalSession(updatedHostedSession)
-
+    // Land the new session in the cache *before* `handleTerminalSession` tears
+    // the transport down, so the UI can never lose a race against its own
+    // teardown. (Necessary but not sufficient on its own: Apollo suppresses
+    // cache-driven notifications while a request is in flight, so the resolved
+    // `session` below is what actually gets the status to the page.)
     const cachedQuery = client.readQuery<GetHostedSessionQuery>({
       query: GetHostedSessionDocument,
     })
@@ -126,12 +133,32 @@ const useHostedSessionValue = (): UseHostedSessionHook => {
       query: GetHostedSessionDocument,
       data: updatedQuery,
     })
+
+    handleTerminalSession(updatedHostedSession)
   }
 
-  const hostedSession = data?.hostedSession?.session
+  const queriedSession = data?.hostedSession?.session
+  const queriedSessionStatus = queriedSession?.status
+
+  // A terminal status, once known from any source, must reach the page.
+  //
+  // The query observable cannot be relied on for this. When the `sessionCompleted`
+  // frame lands while a `GetHostedSession` poll is in flight, `handleTerminalSession`
+  // aborts that poll; Apollo parks the observable on the resulting cancellation
+  // (networkStatus `error`) and keeps serving the last pre-completion snapshot.
+  // Because `isTerminated` blocks every subsequent request, nothing ever refreshes
+  // it — so `data` stays ACTIVE forever even though the cache says COMPLETED.
+  // Preferring the terminal payload here makes the redirect independent of the
+  // query resolving at all.
+  const hasStaleQueriedSession =
+    !isNil(terminalSession) && !isTerminalSessionStatus(queriedSessionStatus)
+  const hostedSession = hasStaleQueriedSession
+    ? terminalSession
+    : queriedSession
+  const hasTerminalSession = isTerminalSessionStatus(hostedSession?.status)
+
   const sessionId = hostedSession?.id
   const organizationSlug = hostedSession?.organization_slug
-  const sessionStatus = hostedSession?.status
   const pathwayId = hostedSession?.pathway_id
   const stakeholderId = hostedSession?.stakeholder?.id
   const stakeholderName = hostedSession?.stakeholder?.name
@@ -214,12 +241,14 @@ const useHostedSessionValue = (): UseHostedSessionHook => {
   }, [organizationSlug])
 
   // Handle session completion/expiration status
-  // Only runs when session status changes
+  // Only runs when session status changes.
+  // Deliberately keyed on the *queried* session: this is the poll path noticing a
+  // terminal status. The push path calls handleTerminalSession directly.
   useEffect(() => {
-    if (isTerminalSessionStatus(sessionStatus) && hostedSession) {
-      handleTerminalSession(hostedSession)
+    if (isTerminalSessionStatus(queriedSessionStatus) && queriedSession) {
+      handleTerminalSession(queriedSession)
     }
-  }, [sessionStatus, hostedSession])
+  }, [queriedSessionStatus, queriedSession])
 
   useEffect(() => {
     if (isSessionCompleted) {
@@ -241,15 +270,57 @@ const useHostedSessionValue = (): UseHostedSessionHook => {
     }
   }, [client, onHostedSessionExpired.data])
 
-  if (loading) {
+  // The fingerprint of the deadlock this hook used to sit in: the push path knows
+  // the session ended, the query observable still reports the old status, and no
+  // request will ever reconcile them. The session below is resolved from the push
+  // payload, so this is a warning about the transport, not a broken page.
+  useEffect(() => {
+    if (!hasStaleQueriedSession) return
+
+    logger.warn(
+      'Hosted session query is serving a stale status after session completion',
+      LogEvent.SESSION_TERMINAL_STATUS_DIVERGED,
+      {
+        session_id: terminalSession?.id,
+        terminal_session_status: terminalSession?.status,
+        queried_session_status: queriedSessionStatus ?? null,
+        query_loading: loading,
+        query_error: error?.message,
+        request_lifecycle_terminated: requestLifecycle.isTerminated,
+      }
+    )
+  }, [hasStaleQueriedSession])
+
+  // No request can settle once the lifecycle is terminated, so a query that is
+  // still loading past a few poll intervals is wedged rather than slow.
+  useEffect(() => {
+    if (!loading) return
+
+    const timeout = setTimeout(() => {
+      logger.warn(
+        'Hosted session query has not settled',
+        LogEvent.SESSION_QUERY_STALLED,
+        {
+          stalled_for_ms: STALLED_SESSION_QUERY_MS,
+          session_id: sessionId,
+          queried_session_status: queriedSessionStatus ?? null,
+          has_terminal_session: hasTerminalSession,
+          request_lifecycle_terminated: requestLifecycle.isTerminated,
+        }
+      )
+    }, STALLED_SESSION_QUERY_MS)
+
+    return () => clearTimeout(timeout)
+  }, [loading, queriedSessionStatus, hasTerminalSession])
+
+  // A cancelled request must not look like an error (below) — and must not look
+  // like `loading` either. Either way, a session we already know to be terminal
+  // has to be returned so the page can redirect.
+  if (loading && !hasTerminalSession) {
     return { loading: true, theme: defaultTheme, startPolling, stopPolling }
   }
 
-  if (
-    error &&
-    !isGraphQLRequestCancellation(error) &&
-    !isTerminalSessionStatus(sessionStatus)
-  ) {
+  if (error && !isGraphQLRequestCancellation(error) && !hasTerminalSession) {
     const unauthorizedError = error.graphQLErrors?.find(
       (err) => err.extensions?.code === 'UNAUTHORIZED'
     )
@@ -276,7 +347,7 @@ const useHostedSessionValue = (): UseHostedSessionHook => {
 
   return {
     loading: false,
-    session: data?.hostedSession?.session,
+    session: hostedSession,
     metadata: data?.hostedSession?.metadata,
     branding: data?.hostedSession?.branding,
     theme: getTheme(data?.hostedSession?.branding?.custom_theme),

--- a/src/services/graphql/apollo-client.test.ts
+++ b/src/services/graphql/apollo-client.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { LogEvent } from '../../utils/logging'
+import { createGraphQLRequestLifecycle } from './apollo-client'
+
+// `Sentry.logger` is exposed through a non-configurable getter, so the module is
+// replaced wholesale rather than spied on.
+const { sentryLogger } = vi.hoisted(() => ({
+  sentryLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('@sentry/nextjs', () => ({ logger: sentryLogger }))
+
+describe('createGraphQLRequestLifecycle — teardown observability', () => {
+  const warn = sentryLogger.warn
+
+  beforeEach(() => {
+    warn.mockClear()
+  })
+
+  it('names the in-flight operations it aborts', () => {
+    const lifecycle = createGraphQLRequestLifecycle()
+    const poll = new AbortController()
+    const activities = new AbortController()
+
+    lifecycle.trackRequest(poll, 'abort', 'GetHostedSession')
+    lifecycle.trackRequest(activities, 'abort', 'GetHostedSessionActivities')
+
+    lifecycle.cancelPendingRequests()
+
+    expect(poll.signal.aborted).toBe(true)
+    expect(activities.signal.aborted).toBe(true)
+    expect(warn).toHaveBeenCalledTimes(1)
+
+    const [message, attributes] = warn.mock.calls[0]
+    expect(message).toContain('Aborted in-flight GraphQL requests')
+    expect(attributes).toMatchObject({
+      event_type: LogEvent.GRAPHQL_REQUESTS_ABORTED,
+      aborted_request_count: 2,
+      operations: ['GetHostedSession', 'GetHostedSessionActivities'],
+    })
+  })
+
+  it('stays quiet when there is nothing in flight to abort', () => {
+    const lifecycle = createGraphQLRequestLifecycle()
+
+    lifecycle.cancelPendingRequests()
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('does not report requests that already settled', () => {
+    const lifecycle = createGraphQLRequestLifecycle()
+    const settled = new AbortController()
+    const inFlight = new AbortController()
+
+    lifecycle.trackRequest(settled, 'abort', 'GetHostedSession')
+    lifecycle.trackRequest(inFlight, 'abort', 'GetMessage')
+    lifecycle.releaseRequest(settled)
+
+    lifecycle.cancelPendingRequests()
+
+    expect(warn.mock.calls[0][1]).toMatchObject({
+      aborted_request_count: 1,
+      operations: ['GetMessage'],
+    })
+  })
+
+  it('rejects new requests after termination', () => {
+    const lifecycle = createGraphQLRequestLifecycle()
+    const late = new AbortController()
+
+    lifecycle.cancelPendingRequests()
+    lifecycle.trackRequest(late, 'abort', 'GetHostedSession')
+
+    expect(lifecycle.isTerminated).toBe(true)
+    expect(late.signal.aborted).toBe(true)
+  })
+})

--- a/src/services/graphql/apollo-client.ts
+++ b/src/services/graphql/apollo-client.ts
@@ -59,7 +59,10 @@ interface SettlingRequest {
 }
 
 export const createGraphQLRequestLifecycle = (): GraphQLRequestLifecycle => {
-  const abortableRequestControllers = new Set<AbortController>()
+  // Keyed by controller so teardown can name the operations it aborted. An
+  // aborted request produces no error UI and no further network traffic, so the
+  // operation names are the only trace it leaves behind.
+  const abortableRequestControllers = new Map<AbortController, string>()
   const settlingRequestControllers = new Map<AbortController, SettlingRequest>()
   const failedSettlingOperations = new Map<string, number>()
   const latestSuccessfulAttempts = new Map<string, number>()
@@ -104,7 +107,7 @@ export const createGraphQLRequestLifecycle = (): GraphQLRequestLifecycle => {
           attempt,
         })
       } else {
-        abortableRequestControllers.add(controller)
+        abortableRequestControllers.set(controller, operationIdentity)
       }
     },
     releaseRequest: (controller, outcome = 'succeeded') => {
@@ -153,10 +156,26 @@ export const createGraphQLRequestLifecycle = (): GraphQLRequestLifecycle => {
     cancelPendingRequests: ({ abortSettling = false } = {}) => {
       isTerminated = true
 
-      abortableRequestControllers.forEach((controller) => {
+      const abortedOperations = Array.from(abortableRequestControllers.values())
+      abortableRequestControllers.forEach((_operationIdentity, controller) => {
         controller.abort()
       })
       abortableRequestControllers.clear()
+
+      // Aborting an in-flight read leaves the corresponding Apollo observable
+      // parked: no result, no error, and no retry (new requests are blocked from
+      // here on). Without this line the client simply goes silent.
+      if (abortedOperations.length > 0) {
+        logger.warn(
+          'Aborted in-flight GraphQL requests during teardown',
+          LogEvent.GRAPHQL_REQUESTS_ABORTED,
+          {
+            aborted_request_count: abortedOperations.length,
+            operations: abortedOperations,
+            abort_settling: abortSettling,
+          }
+        )
+      }
 
       if (abortSettling) {
         settlingRequestControllers.forEach((request, controller) => {

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -16,6 +16,10 @@ export enum LogEvent {
   SESSION_EXPIRED = 'SESSION_EXPIRED',
   SESSION_COMPLETED = 'SESSION_COMPLETED',
   SESSION_EXIT = 'SESSION_EXIT',
+  /** A terminal status was known from the push path while the query still reported an older one. */
+  SESSION_TERMINAL_STATUS_DIVERGED = 'SESSION_TERMINAL_STATUS_DIVERGED',
+  /** `useGetHostedSessionQuery` stayed in a loading state past several poll intervals. */
+  SESSION_QUERY_STALLED = 'SESSION_QUERY_STALLED',
 
   MESSAGE_MARKING_AS_READ = 'MESSAGE_MARKING_AS_READ',
   MESSAGE_MARKED_AS_READ = 'MESSAGE_MARKED_AS_READ',
@@ -62,6 +66,8 @@ export enum LogEvent {
   GRAPHQL_WS_PONG = 'GRAPHQL_WS_PONG',
   GRAPHQL_WS_KEEPALIVE_TIMEOUT = 'GRAPHQL_WS_KEEPALIVE_TIMEOUT',
   GRAPHQL_WS_MESSAGE = 'GRAPHQL_WS_MESSAGE',
+  /** `cancelPendingRequests()` aborted one or more in-flight requests. */
+  GRAPHQL_REQUESTS_ABORTED = 'GRAPHQL_REQUESTS_ABORTED',
 
   REMOTE_SINGLE_SELECT_OPTIONS = 'REMOTE_SINGLE_SELECT_OPTIONS',
 

--- a/test/hostedSessionHarness.tsx
+++ b/test/hostedSessionHarness.tsx
@@ -1,0 +1,332 @@
+/**
+ * Test harness for the hosted-session state machine.
+ *
+ * It deliberately uses the *real* `createClient` link chain (authentication →
+ * request lifecycle → retry → error → http) rather than `MockedProvider`,
+ * because the bug this harness exists to pin down lives in the interaction
+ * between `cancelPendingRequests()`, `AbortController`, and Apollo's polling
+ * observable. `MockedProvider` replaces exactly the layer under test.
+ *
+ * Two things are controllable:
+ *  - `fetchController` — every GraphQL HTTP request stays in flight until the
+ *    test resolves it, so "a poll is in flight right now" is deterministic.
+ *  - `subscriptionController` — pushes `sessionCompleted` / `sessionExpired`
+ *    frames on demand, standing in for the websocket.
+ */
+import {
+  ApolloLink,
+  ApolloProvider,
+  type FetchResult,
+  Observable,
+  type Operation,
+} from '@apollo/client'
+import { getMainDefinition } from '@apollo/client/utilities'
+import { render } from '@testing-library/react'
+import React, { type ReactNode } from 'react'
+import { vi } from 'vitest'
+import {
+  HostedSessionProvider,
+  useHostedSession,
+} from '../src/hooks/useHostedSession'
+import type { UseHostedSessionHook } from '../src/hooks/useHostedSession/useHostedSession'
+import {
+  createClient,
+  createGraphQLRequestLifecycle,
+  type GraphQLRequestLifecycle,
+  GraphQLRequestLifecycleContext,
+} from '../src/services/graphql'
+import fragmentTypes from '../src/types/generated/fragment-types'
+import {
+  GetHostedSessionDocument,
+  HostedSessionStakeholderType,
+  HostedSessionStatus,
+} from '../src/types/generated/types-orchestration'
+
+const HTTP_URI = 'https://api.test.awell.health/graphql'
+const WS_URI = 'wss://api.test.awell.health/graphql'
+
+export const SESSION_ID = 'GpQ2OeoFxwm9'
+export const SUCCESS_URL = 'https://developers.awellhealth.com/'
+export const CANCEL_URL = 'https://awell.health/cancelled'
+
+export const buildSession = (status: HostedSessionStatus) => ({
+  __typename: 'HostedSession' as const,
+  id: SESSION_ID,
+  pathway_id: 'qVx9NKTmQonN',
+  status,
+  success_url: SUCCESS_URL,
+  cancel_url: CANCEL_URL,
+  organization_slug: 'awell-dev',
+  stakeholder: {
+    __typename: 'HostedSessionStakeholder' as const,
+    id: 'stakeholder-1',
+    type: HostedSessionStakeholderType.Patient,
+    name: 'Test Patient',
+  },
+})
+
+export const buildHostedSessionQueryData = (status: HostedSessionStatus) => ({
+  __typename: 'Query' as const,
+  hostedSession: {
+    __typename: 'HostedSessionPayload' as const,
+    session: buildSession(status),
+    branding: {
+      __typename: 'BrandingSettings' as const,
+      logo_url: null,
+      hosted_page_title: 'Awell',
+      accent_color: '#004ac2',
+      hosted_page_auto_progress: null,
+      hosted_page_autosave: null,
+      custom_theme: null,
+    },
+    metadata: {
+      __typename: 'SessionMetadata' as const,
+      pathway_definition_id: 'definition-1',
+      tenant_id: 'tenant-1',
+    },
+  },
+})
+
+interface CapturedRequest {
+  operationName: string
+  /** Resolve the request with a GraphQL payload, as the server would. */
+  resolve: (_data: unknown) => void
+  /** Fail the request the way a dropped connection would. */
+  fail: (_error: Error) => void
+  isSettled: () => boolean
+  isAborted: () => boolean
+}
+
+const jsonResponse = (payload: unknown) => ({
+  status: 200,
+  ok: true,
+  headers: {
+    get: (name: string) =>
+      name.toLowerCase() === 'content-type' ? 'application/json' : null,
+  },
+  text: () => Promise.resolve(JSON.stringify(payload)),
+})
+
+export interface FetchController {
+  requests: Array<CapturedRequest>
+  requestsFor: (_operationName: string) => Array<CapturedRequest>
+  pendingFor: (_operationName: string) => Array<CapturedRequest>
+}
+
+/**
+ * Replaces `globalThis.fetch` with a queue the test drives by hand. Requests
+ * honour their `AbortSignal` exactly as a real fetch does: they reject with a
+ * DOMException named `AbortError`.
+ */
+export const installFetchController = (): FetchController => {
+  const requests: Array<CapturedRequest> = []
+
+  const controller: FetchController = {
+    requests,
+    requestsFor: (operationName) =>
+      requests.filter((request) => request.operationName === operationName),
+    pendingFor: (operationName) =>
+      requests.filter(
+        (request) =>
+          request.operationName === operationName && !request.isSettled()
+      ),
+  }
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((_url: string, options: RequestInit = {}) => {
+      const body = JSON.parse(String(options.body ?? '{}'))
+      let settled = false
+      let aborted = false
+
+      const request: CapturedRequest = {
+        operationName: body.operationName ?? 'unknown',
+        resolve: () => undefined,
+        fail: () => undefined,
+        isSettled: () => settled,
+        isAborted: () => aborted,
+      }
+
+      const promise = new Promise((resolve, reject) => {
+        request.resolve = (data) => {
+          if (settled) return
+          settled = true
+          resolve(jsonResponse(data))
+        }
+        request.fail = (error) => {
+          if (settled) return
+          settled = true
+          reject(error)
+        }
+
+        const signal = options.signal
+        if (signal) {
+          const onAbort = () => {
+            aborted = true
+            if (settled) return
+            settled = true
+            reject(new DOMException('The operation was aborted.', 'AbortError'))
+          }
+          if (signal.aborted) {
+            onAbort()
+          } else {
+            signal.addEventListener('abort', onAbort, { once: true })
+          }
+        }
+      })
+
+      requests.push(request)
+      return promise
+    })
+  )
+
+  return controller
+}
+
+export interface SubscriptionController {
+  link: ApolloLink
+  /** Number of live subscribers for an operation. */
+  subscriberCount: (_operationName: string) => number
+  /** Push a frame to every live subscriber of an operation. */
+  emit: (_operationName: string, _data: unknown) => void
+}
+
+const isSubscriptionOperation = (operation: Operation): boolean => {
+  const definition = getMainDefinition(operation.query)
+  return (
+    definition.kind === 'OperationDefinition' &&
+    definition.operation === 'subscription'
+  )
+}
+
+export const createSubscriptionController = (): SubscriptionController => {
+  const subscribers = new Map<
+    string,
+    Set<{ next: (_value: FetchResult) => void }>
+  >()
+
+  const link = new ApolloLink((operation, forward) => {
+    if (!isSubscriptionOperation(operation)) {
+      return forward(operation)
+    }
+
+    return new Observable<FetchResult>((observer) => {
+      const forOperation =
+        subscribers.get(operation.operationName) ??
+        new Set<{ next: (_value: FetchResult) => void }>()
+      forOperation.add(observer)
+      subscribers.set(operation.operationName, forOperation)
+
+      return () => {
+        forOperation.delete(observer)
+      }
+    })
+  })
+
+  return {
+    link,
+    subscriberCount: (operationName) =>
+      subscribers.get(operationName)?.size ?? 0,
+    emit: (operationName, data) => {
+      const forOperation = subscribers.get(operationName)
+      if (!forOperation || forOperation.size === 0) {
+        throw new Error(`No live subscribers for ${operationName}`)
+      }
+      forOperation.forEach((observer) => observer.next({ data } as FetchResult))
+    },
+  }
+}
+
+export interface HostedSessionHarness {
+  fetchController: FetchController
+  subscriptionController: SubscriptionController
+  requestLifecycle: GraphQLRequestLifecycle
+  /** Latest value returned by `useHostedSession()`. */
+  current: () => UseHostedSessionHook
+  renderCount: () => number
+  unmount: () => void
+  /** Session status as normalised in the Apollo cache. */
+  readCachedStatus: () => string | undefined
+  readCacheEntity: () => unknown
+  networkStatus: () => number | undefined
+}
+
+export const renderHostedSession = (): HostedSessionHarness => {
+  const fetchController = installFetchController()
+  const subscriptionController = createSubscriptionController()
+  const requestLifecycle = createGraphQLRequestLifecycle()
+
+  const client = createClient({
+    httpUri: HTTP_URI,
+    wsUri: WS_URI,
+    extraLinks: [subscriptionController.link],
+    cacheConfig: { possibleTypes: fragmentTypes.possibleTypes },
+    requestLifecycle,
+  })
+
+  let latest: UseHostedSessionHook | undefined
+  let renders = 0
+
+  const Probe = () => {
+    latest = useHostedSession()
+    renders += 1
+    return null
+  }
+
+  const Wrapper = ({ children }: { children?: ReactNode }) => (
+    <GraphQLRequestLifecycleContext.Provider value={requestLifecycle}>
+      <ApolloProvider client={client}>
+        <HostedSessionProvider>{children}</HostedSessionProvider>
+      </ApolloProvider>
+    </GraphQLRequestLifecycleContext.Provider>
+  )
+
+  const { unmount } = render(
+    <Wrapper>
+      <Probe />
+    </Wrapper>
+  )
+
+  return {
+    fetchController,
+    subscriptionController,
+    requestLifecycle,
+    current: () => {
+      if (!latest) {
+        throw new Error('useHostedSession has not rendered yet')
+      }
+      return latest
+    },
+    renderCount: () => renders,
+    unmount,
+    readCachedStatus: () => {
+      const cached = client.readQuery<{
+        hostedSession: { session: { status: string } }
+      }>({ query: GetHostedSessionDocument })
+      return cached?.hostedSession?.session?.status
+    },
+    readCacheEntity: () =>
+      (client.cache.extract() as Record<string, unknown>)[
+        `HostedSession:${SESSION_ID}`
+      ],
+    networkStatus: () => {
+      const queries = Array.from(
+        (
+          client as unknown as {
+            queryManager: {
+              getObservableQueries: (
+                _include: string
+              ) => Map<string, { getCurrentResult: () => unknown }>
+            }
+          }
+        ).queryManager
+          .getObservableQueries('all')
+          .values()
+      )
+      const currentResult = queries[0]?.getCurrentResult() as
+        | { networkStatus?: number }
+        | undefined
+      return currentResult?.networkStatus
+    },
+  }
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,15 @@
+import { cleanup } from '@testing-library/react'
+import { afterEach, beforeEach } from 'vitest'
+
+// The Apollo client factory reads credentials from sessionStorage and refuses to
+// open a websocket when subscriptions are disabled for tests. Both are required
+// for `createClient` to build a usable link chain under jsdom.
+beforeEach(() => {
+  sessionStorage.clear()
+  sessionStorage.setItem('accessToken', 'test-access-token')
+  sessionStorage.setItem('TEST_DISABLE_SUBSCRIPTIONS', 'true')
+})
+
+afterEach(() => {
+  cleanup()
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./test/setup.ts'],
+    include: ['{src,pages,lib,test}/**/*.{test,spec}.{ts,tsx}'],
+    restoreMocks: true,
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,6 +195,15 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
+"@babel/code-frame@^7.10.4":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/code-frame@^7.22.13":
   version "7.22.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
@@ -608,6 +617,11 @@
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
 "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
@@ -1583,6 +1597,121 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
+"@esbuild/aix-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
+  integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
+
+"@esbuild/android-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
+  integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
+
+"@esbuild/android-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
+  integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
+
+"@esbuild/android-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
+  integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
+
+"@esbuild/darwin-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
+  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+
+"@esbuild/darwin-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
+  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
+
+"@esbuild/freebsd-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
+  integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
+
+"@esbuild/freebsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
+  integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
+
+"@esbuild/linux-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
+  integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
+
+"@esbuild/linux-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
+  integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
+
+"@esbuild/linux-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
+  integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
+
+"@esbuild/linux-loong64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
+  integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
+
+"@esbuild/linux-mips64el@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
+  integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
+
+"@esbuild/linux-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
+  integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
+
+"@esbuild/linux-riscv64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
+  integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
+
+"@esbuild/linux-s390x@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
+  integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
+
+"@esbuild/linux-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
+  integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
+
+"@esbuild/netbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
+  integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
+
+"@esbuild/openbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
+  integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
+
+"@esbuild/sunos-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
+  integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
+
+"@esbuild/win32-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
+  integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
+
+"@esbuild/win32-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
+  integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
+
+"@esbuild/win32-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
+  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -2284,6 +2413,13 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
@@ -2835,6 +2971,11 @@
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@n1ru4l/graphql-live-query/-/graphql-live-query-0.10.0.tgz#2306151630b0e74b017cc1067ebbea351acf56f8"
   integrity sha512-qZ7OHH/NB0NcG/Xa7irzgjE63UH0CkofZT0Bw4Ko6iRFagPRHBM8RgFXwTt/6JbFGIEUS4STRtaFoc/Eq/ZtzQ==
+
+"@napi-rs/lzma-linux-x64-gnu@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz#e57d4306966078662038094fb38eb9146dc3aea9"
+  integrity sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==
 
 "@next/env@14.2.35":
   version "14.2.35"
@@ -3707,110 +3848,235 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz#7e478b66180c5330429dd161bf84dad66b59c8eb"
   integrity sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==
 
+"@rollup/rollup-android-arm-eabi@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz#2b86c8fff13a065845ddb65f64d814499ace020f"
+  integrity sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==
+
 "@rollup/rollup-android-arm64@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz#2b025510c53a5e3962d3edade91fba9368c9d71c"
   integrity sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==
+
+"@rollup/rollup-android-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz#af217357ecc06ae5e4f54ef34ee72b1e37f8dbc3"
+  integrity sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==
 
 "@rollup/rollup-darwin-arm64@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz#3577c38af68ccf34c03e84f476bfd526abca10a0"
   integrity sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==
 
+"@rollup/rollup-darwin-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz#e9d0adba06e39b632fc8e880100ff06547eda80b"
+  integrity sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==
+
 "@rollup/rollup-darwin-x64@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz#2bf5f2520a1f3b551723d274b9669ba5b75ed69c"
   integrity sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==
+
+"@rollup/rollup-darwin-x64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz#eff983a29db7d8ea7f733f1ce430fc64e159a5e6"
+  integrity sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==
 
 "@rollup/rollup-freebsd-arm64@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz#4bb9cc80252564c158efc0710153c71633f1927c"
   integrity sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==
 
+"@rollup/rollup-freebsd-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz#abe1399a70e819034f492d05dbcc97964310bb57"
+  integrity sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==
+
 "@rollup/rollup-freebsd-x64@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz#2301289094d49415a380cf942219ae9d8b127440"
   integrity sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==
+
+"@rollup/rollup-freebsd-x64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz#b2e0f8c24a362ac7112be3d5549c6940597e0168"
+  integrity sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==
 
 "@rollup/rollup-linux-arm-gnueabihf@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz#1d03d776f2065e09fc141df7d143476e94acca88"
   integrity sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==
 
+"@rollup/rollup-linux-arm-gnueabihf@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz#a5f2a7e7eb719254a6800db18e9f369d3c623439"
+  integrity sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==
+
 "@rollup/rollup-linux-arm-musleabihf@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz#8623de0e040b2fd52a541c602688228f51f96701"
   integrity sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==
+
+"@rollup/rollup-linux-arm-musleabihf@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz#390c86c797695af87c38d6f005222d920b5bfa22"
+  integrity sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==
 
 "@rollup/rollup-linux-arm64-gnu@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz#ce2d1999bc166277935dde0301cde3dd0417fb6e"
   integrity sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==
 
+"@rollup/rollup-linux-arm64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz#1fea78609a15813cda98d93fe8d987c87017f572"
+  integrity sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==
+
 "@rollup/rollup-linux-arm64-musl@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz#88c2523778444da952651a2219026416564a4899"
   integrity sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==
+
+"@rollup/rollup-linux-arm64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz#3b50031c9916517576098f6e11b38a13147dc463"
+  integrity sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==
 
 "@rollup/rollup-linux-loong64-gnu@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz#578ca2220a200ac4226c536c10c8cc6e4f276714"
   integrity sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==
 
+"@rollup/rollup-linux-loong64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz#b403255546099a4300b17d976ee1776224c090e5"
+  integrity sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==
+
+"@rollup/rollup-linux-loong64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz#5900610e59c66ee594539c6590566dbfda7082b1"
+  integrity sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==
+
 "@rollup/rollup-linux-ppc64-gnu@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz#aa338d3effd4168a20a5023834a74ba2c3081293"
   integrity sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==
+
+"@rollup/rollup-linux-ppc64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz#a892cc8b8414bc8ae0b267816b5e384e5d321ff2"
+  integrity sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==
+
+"@rollup/rollup-linux-ppc64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz#d9e60d568b7db4df2196fb2411b0c6918b2360cc"
+  integrity sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==
 
 "@rollup/rollup-linux-riscv64-gnu@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz#16ba582f9f6cff58119aa242782209b1557a1508"
   integrity sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==
 
+"@rollup/rollup-linux-riscv64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz#5b3141ab43afbd9e50f639e562e94ed256d201cf"
+  integrity sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==
+
 "@rollup/rollup-linux-riscv64-musl@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz#e404a77ebd6378483888b8064c703adb011340ab"
   integrity sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==
+
+"@rollup/rollup-linux-riscv64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz#b0fe751015bc3822f9004884eaba5e5cdfde7aa6"
+  integrity sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==
 
 "@rollup/rollup-linux-s390x-gnu@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz#92ad52d306227c56bec43d96ad2164495437ffe6"
   integrity sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==
 
+"@rollup/rollup-linux-s390x-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz#0cb323e850509e1b9bf6d241328a98b0e12e2916"
+  integrity sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==
+
 "@rollup/rollup-linux-x64-gnu@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz#fd0dea3bb9aa07e7083579f25e1c2285a46cb9fa"
   integrity sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==
+
+"@rollup/rollup-linux-x64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz#1e7470123e7a8ba8c160a7a043447472d5549542"
+  integrity sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==
 
 "@rollup/rollup-linux-x64-musl@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz#37a3efb09f18d555f8afc490e1f0444885de8951"
   integrity sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==
 
+"@rollup/rollup-linux-x64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz#19df9a17d20ff3c17bd8e9cc2553563ae0aa0580"
+  integrity sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==
+
+"@rollup/rollup-openbsd-x64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz#31c3ca1bd00e80f309a1d0cb8da4bdf59cb2dfa3"
+  integrity sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==
+
 "@rollup/rollup-openharmony-arm64@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz#c489bec9f4f8320d42c9b324cca220c90091c1f7"
   integrity sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==
+
+"@rollup/rollup-openharmony-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz#84561a14381caecb7652e158d10551a5edc0a6fc"
+  integrity sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==
 
 "@rollup/rollup-win32-arm64-msvc@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz#152832b5f79dc22d1606fac3db946283601b7080"
   integrity sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==
 
+"@rollup/rollup-win32-arm64-msvc@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz#bc532edb20cd39c0b53eee2dfae43b52c2e3be1e"
+  integrity sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==
+
 "@rollup/rollup-win32-ia32-msvc@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz#54d91b2bb3bf3e9f30d32b72065a4e52b3a172a5"
   integrity sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==
+
+"@rollup/rollup-win32-ia32-msvc@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz#a6f51492976c9fc19801be298df2f76a3cbebf7a"
+  integrity sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==
 
 "@rollup/rollup-win32-x64-gnu@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz#df9df03e61a003873efec8decd2034e7f135c71e"
   integrity sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==
 
+"@rollup/rollup-win32-x64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz#ae60710b0868b2fe731d9f7c341fa49cbf8e8629"
+  integrity sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==
+
 "@rollup/rollup-win32-x64-msvc@4.53.3":
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz#38ae84f4c04226c1d56a3b17296ef1e0460ecdfe"
   integrity sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==
+
+"@rollup/rollup-win32-x64-msvc@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz#c3a265fe0f9af4fb63bad86d3829386bc5da0026"
+  integrity sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -4052,6 +4318,11 @@
     unplugin "1.0.1"
     uuid "^9.0.0"
 
+"@sinclair/typebox@^0.27.8":
+  version "0.27.12"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.12.tgz#0cacd3cff047a32936b1ace47ea7c86eaab60a7f"
+  integrity sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==
+
 "@stitches/core@^1.2.6":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@stitches/core/-/core-1.2.8.tgz#dce3b8fdc764fbc6dbea30c83b73bfb52cf96173"
@@ -4101,6 +4372,29 @@
   resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.10.8.tgz#975446a667755222f62884c19e5c3c66d959b8b4"
   integrity sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==
 
+"@testing-library/dom@^9.0.0":
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.4.tgz#50696ec28376926fec0a1bf87d9dbac5e27f60ce"
+  integrity sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.1.3"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@^14.3.1":
+  version "14.3.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.3.1.tgz#29513fc3770d6fb75245c4e1245c470e4ffdd830"
+  integrity sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^9.0.0"
+    "@types/react-dom" "^18.0.0"
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -4125,6 +4419,11 @@
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/babel__core@^7.20.2":
   version "7.20.3"
@@ -4189,6 +4488,11 @@
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/estree@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
 "@types/hast@^3.0.0":
   version "3.0.2"
@@ -4348,6 +4652,11 @@
   integrity sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==
   dependencies:
     "@types/react" "*"
+
+"@types/react-dom@^18.0.0":
+  version "18.3.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
+  integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
 "@types/react-transition-group@^4.4.0":
   version "4.4.12"
@@ -4721,6 +5030,50 @@
     "@types/babel__core" "^7.20.2"
     react-refresh "^0.14.0"
 
+"@vitest/expect@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-1.6.1.tgz#b90c213f587514a99ac0bf84f88cff9042b0f14d"
+  integrity sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==
+  dependencies:
+    "@vitest/spy" "1.6.1"
+    "@vitest/utils" "1.6.1"
+    chai "^4.3.10"
+
+"@vitest/runner@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-1.6.1.tgz#10f5857c3e376218d58c2bfacfea1161e27e117f"
+  integrity sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==
+  dependencies:
+    "@vitest/utils" "1.6.1"
+    p-limit "^5.0.0"
+    pathe "^1.1.1"
+
+"@vitest/snapshot@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-1.6.1.tgz#90414451a634bb36cd539ccb29ae0d048a8c0479"
+  integrity sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==
+  dependencies:
+    magic-string "^0.30.5"
+    pathe "^1.1.1"
+    pretty-format "^29.7.0"
+
+"@vitest/spy@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-1.6.1.tgz#33376be38a5ed1ecd829eb986edaecc3e798c95d"
+  integrity sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==
+  dependencies:
+    tinyspy "^2.2.0"
+
+"@vitest/utils@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-1.6.1.tgz#6d2f36cb6d866f2bbf59da854a324d6bf8040f17"
+  integrity sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==
+  dependencies:
+    diff-sequences "^29.6.3"
+    estree-walker "^3.0.3"
+    loupe "^2.3.7"
+    pretty-format "^29.7.0"
+
 "@whatwg-node/fetch@^0.2.3", "@whatwg-node/fetch@^0.2.4":
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/@whatwg-node/fetch/-/fetch-0.2.7.tgz#8699d9950d2f07365b2b49936ceca551c18757ba"
@@ -4801,10 +5154,22 @@ acorn-walk@^8.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
+acorn-walk@^8.3.2:
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
+  integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
+  dependencies:
+    acorn "^8.11.0"
+
 acorn@^8.0.0:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
+
+acorn@^8.11.0, acorn@^8.16.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.18.0.tgz#4faf01b2d6d326bfeed97aea1f52220b5f4c1940"
+  integrity sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==
 
 acorn@^8.14.0, acorn@^8.8.1:
   version "8.15.0"
@@ -4889,6 +5254,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 ansi-styles@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.1.0.tgz#87313c102b8118abd57371afab34618bf7350ed3"
@@ -4924,12 +5294,19 @@ aria-hidden@^1.2.4:
   dependencies:
     tslib "^2.0.0"
 
+aria-query@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
+  integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
+  dependencies:
+    deep-equal "^2.0.5"
+
 aria-query@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
 
-array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
+array-buffer-byte-length@^1.0.0, array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz#384d12a37295aec3769ab022ad323a18a51ccf8b"
   integrity sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==
@@ -5051,6 +5428,11 @@ asn1js@^3.0.1, asn1js@^3.0.5:
     pvtsutils "^1.3.2"
     pvutils "^1.1.3"
     tslib "^2.4.0"
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 ast-types-flow@^0.0.8:
   version "0.0.8"
@@ -5296,10 +5678,23 @@ busboy@1.6.0, busboy@^1.6.0:
   dependencies:
     streamsearch "^1.1.0"
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz#32e5892e6361b29b0b545ba6f7763378daca2840"
   integrity sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
+call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
   dependencies:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
@@ -5311,6 +5706,16 @@ call-bind@^1.0.0, call-bind@^1.0.2:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
+
+call-bind@^1.0.5, call-bind@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
+  integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    get-intrinsic "^1.3.0"
+    set-function-length "^1.2.2"
 
 call-bind@^1.0.7:
   version "1.0.7"
@@ -5340,6 +5745,14 @@ call-bound@^1.0.2, call-bound@^1.0.3:
   dependencies:
     call-bind-apply-helpers "^1.0.1"
     get-intrinsic "^1.2.6"
+
+call-bound@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -5392,6 +5805,19 @@ ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
+chai@^4.3.10:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.5.0.tgz#707e49923afdd9b13a8b0b47d33d732d13812fd8"
+  integrity sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.3"
+    deep-eql "^4.1.3"
+    get-func-name "^2.0.2"
+    loupe "^2.3.6"
+    pathval "^1.1.1"
+    type-detect "^4.1.0"
 
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
@@ -5468,6 +5894,13 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
+  integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
+  dependencies:
+    get-func-name "^2.0.2"
 
 chokidar@^3.5.2:
   version "3.5.3"
@@ -5704,6 +6137,11 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+confbox@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.8.tgz#820d73d3b3c82d9bd910652c5d4d599ef8ff8b06"
+  integrity sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==
 
 constant-case@^3.0.4:
   version "3.0.4"
@@ -5969,6 +6407,37 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
+deep-eql@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.4.tgz#d0d3912865911bb8fac5afb4e3acfa6a28dc72b7"
+  integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
+  dependencies:
+    type-detect "^4.0.0"
+
+deep-equal@^2.0.5:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.3.tgz#af89dafb23a396c7da3e862abc0be27cf51d56e1"
+  integrity sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.5"
+    es-get-iterator "^1.1.3"
+    get-intrinsic "^1.2.2"
+    is-arguments "^1.1.1"
+    is-array-buffer "^3.0.2"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.5.1"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.13"
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -6053,6 +6522,11 @@ devlop@^1.0.0, devlop@^1.1.0:
   dependencies:
     dequal "^2.0.0"
 
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -6088,6 +6562,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dom-helpers@^5.0.1:
   version "5.2.1"
@@ -6378,6 +6857,21 @@ es-errors@^1.3.0:
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
+es-get-iterator@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
+  integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    is-arguments "^1.1.1"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.7"
+    isarray "^2.0.5"
+    stop-iteration-iterator "^1.0.0"
+
 es-iterator-helpers@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz#d1dd0f58129054c0ad922e6a9a1e65eef435fe75"
@@ -6404,6 +6898,13 @@ es-object-atoms@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-object-atoms@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
   dependencies:
     es-errors "^1.3.0"
 
@@ -6468,6 +6969,35 @@ es6-symbol@^3, es6-symbol@^3.1.1, es6-symbol@^3.1.3:
   dependencies:
     d "^1.0.2"
     ext "^1.7.0"
+
+esbuild@^0.21.3:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
+  integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.21.5"
+    "@esbuild/android-arm" "0.21.5"
+    "@esbuild/android-arm64" "0.21.5"
+    "@esbuild/android-x64" "0.21.5"
+    "@esbuild/darwin-arm64" "0.21.5"
+    "@esbuild/darwin-x64" "0.21.5"
+    "@esbuild/freebsd-arm64" "0.21.5"
+    "@esbuild/freebsd-x64" "0.21.5"
+    "@esbuild/linux-arm" "0.21.5"
+    "@esbuild/linux-arm64" "0.21.5"
+    "@esbuild/linux-ia32" "0.21.5"
+    "@esbuild/linux-loong64" "0.21.5"
+    "@esbuild/linux-mips64el" "0.21.5"
+    "@esbuild/linux-ppc64" "0.21.5"
+    "@esbuild/linux-riscv64" "0.21.5"
+    "@esbuild/linux-s390x" "0.21.5"
+    "@esbuild/linux-x64" "0.21.5"
+    "@esbuild/netbsd-x64" "0.21.5"
+    "@esbuild/openbsd-x64" "0.21.5"
+    "@esbuild/sunos-x64" "0.21.5"
+    "@esbuild/win32-arm64" "0.21.5"
+    "@esbuild/win32-ia32" "0.21.5"
+    "@esbuild/win32-x64" "0.21.5"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -6793,6 +7323,13 @@ estree-walker@^2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -6836,6 +7373,21 @@ execa@^6.1.0:
     npm-run-path "^5.1.0"
     onetime "^6.0.0"
     signal-exit "^3.0.7"
+    strip-final-newline "^3.0.0"
+
+execa@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-8.0.1.tgz#51f6a5943b580f963c3ca9c6321796db8cc39b8c"
+  integrity sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^8.0.1"
+    human-signals "^5.0.0"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
 
 ext@^1.7.0:
@@ -7037,6 +7589,13 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
+for-each@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
+  integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
+  dependencies:
+    is-callable "^1.2.7"
+
 foreground-child@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.0.tgz#0ac8644c06e431439f8561db8ecf29a7b5519c77"
@@ -7118,7 +7677,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
+fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -7194,6 +7753,11 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-func-name@^2.0.1, get-func-name@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
+  integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
@@ -7221,6 +7785,22 @@ get-intrinsic@^1.1.3, get-intrinsic@^1.2.1:
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
     hasown "^2.0.0"
+
+get-intrinsic@^1.2.2, get-intrinsic@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
 
 get-intrinsic@^1.2.4:
   version "1.2.4"
@@ -7266,6 +7846,11 @@ get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-stream@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
+  integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
 get-symbol-description@^1.0.0:
   version "1.0.0"
@@ -7717,6 +8302,11 @@ human-signals@^3.0.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
   integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
 
+human-signals@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
+  integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
+
 husky@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
@@ -7908,7 +8498,15 @@ is-alphanumerical@^2.0.0:
     is-alphabetical "^2.0.0"
     is-decimal "^2.0.0"
 
-is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
+is-arguments@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
+  integrity sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==
+  dependencies:
+    call-bound "^1.0.2"
+    has-tostringtag "^1.0.2"
+
+is-array-buffer@^3.0.2, is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz#65742e1e687bd2cc666253068fd8707fe4d44280"
   integrity sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==
@@ -8091,7 +8689,7 @@ is-lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
-is-map@^2.0.3:
+is-map@^2.0.2, is-map@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.3.tgz#ede96b7fe1e270b3c4465e3a465658764926d62e"
   integrity sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==
@@ -8178,7 +8776,7 @@ is-relative@^1.0.0:
   dependencies:
     is-unc-path "^1.0.0"
 
-is-set@^2.0.3:
+is-set@^2.0.2, is-set@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.3.tgz#8ab209ea424608141372ded6e0cb200ef1d9d01d"
   integrity sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==
@@ -8378,6 +8976,11 @@ js-cookie@^2.2.1:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+js-tokens@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.1.tgz#2ec43964658435296f6761b34e10671c2d9527f4"
+  integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
 
 js-video-url-parser@^0.5.1:
   version "0.5.1"
@@ -8632,6 +9235,14 @@ listr2@^4.0.5:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
+local-pkg@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.5.1.tgz#69658638d2a95287534d4c2fff757980100dbb6d"
+  integrity sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==
+  dependencies:
+    mlly "^1.7.3"
+    pkg-types "^1.2.1"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -8746,6 +9357,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^2.3.6, loupe@^2.3.7:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.7.tgz#6e69b7d4db7d3ab436328013d37d1c8c3540c697"
+  integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
+  dependencies:
+    get-func-name "^2.0.1"
+
 lower-case-first@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-2.0.2.tgz#64c2324a2250bf7c37c5901e76a5b5309301160b"
@@ -8779,7 +9397,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lz-string@^1.4.4:
+lz-string@^1.4.4, lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
@@ -8791,7 +9409,7 @@ magic-string@0.30.8:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
 
-magic-string@^0.30.3:
+magic-string@^0.30.3, magic-string@^0.30.5:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
@@ -9608,6 +10226,16 @@ mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mlly@^1.7.3, mlly@^1.7.4:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.8.2.tgz#e7f7919a82d13b174405613117249a3f449d78bb"
+  integrity sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==
+  dependencies:
+    acorn "^8.16.0"
+    pathe "^2.0.3"
+    pkg-types "^1.3.1"
+    ufo "^1.6.3"
+
 module-details-from-path@^1.0.3, module-details-from-path@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
@@ -9663,6 +10291,11 @@ nano-css@^5.6.2:
     rtl-css-js "^1.16.1"
     stacktrace-js "^2.0.2"
     stylis "^4.3.0"
+
+nanoid@^3.3.16:
+  version "3.3.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
+  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 nanoid@^3.3.6:
   version "3.3.6"
@@ -9825,6 +10458,14 @@ object-inspect@^1.13.3:
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.3.tgz#f14c183de51130243d6d18ae149375ff50ea488a"
   integrity sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==
+
+object-is@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.6.tgz#1a6a53aed2dd8f7e6775ff870bea58545956ab07"
+  integrity sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -10008,6 +10649,13 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-5.0.0.tgz#6946d5b7140b649b7a33a027d89b4c625b3a5985"
+  integrity sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
@@ -10159,6 +10807,21 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathe@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
+pathe@^2.0.1, pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 pg-int8@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
@@ -10200,6 +10863,15 @@ pidtree@^0.6.0:
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
   integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
 
+pkg-types@^1.2.1, pkg-types@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.3.1.tgz#bd7cc70881192777eef5326c19deb46e890917df"
+  integrity sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==
+  dependencies:
+    confbox "^0.1.8"
+    mlly "^1.7.4"
+    pathe "^2.0.1"
+
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
@@ -10213,6 +10885,15 @@ postcss@8.4.31:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postcss@^8.4.43:
+  version "8.5.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
+  dependencies:
+    nanoid "^3.3.16"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 postgres-array@~2.0.0:
   version "2.0.0"
@@ -10252,6 +10933,24 @@ prettier@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
 
 prismjs@^1.30.0:
   version "1.30.0"
@@ -10514,10 +11213,15 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.2:
+react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-markdown@^9.0.0:
   version "9.0.0"
@@ -10724,7 +11428,7 @@ regexp.prototype.flags@^1.4.3:
     define-properties "^1.1.3"
     functions-have-names "^1.2.2"
 
-regexp.prototype.flags@^1.5.3:
+regexp.prototype.flags@^1.5.1, regexp.prototype.flags@^1.5.3:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
   integrity sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==
@@ -10924,6 +11628,41 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rollup@^4.20.0:
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.62.4.tgz#96d2e62070f0b0ac63424edd0c93a7fb864ef069"
+  integrity sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==
+  dependencies:
+    "@types/estree" "1.0.9"
+  optionalDependencies:
+    "@napi-rs/lzma-linux-x64-gnu" "1.5.1"
+    "@rollup/rollup-android-arm-eabi" "4.62.4"
+    "@rollup/rollup-android-arm64" "4.62.4"
+    "@rollup/rollup-darwin-arm64" "4.62.4"
+    "@rollup/rollup-darwin-x64" "4.62.4"
+    "@rollup/rollup-freebsd-arm64" "4.62.4"
+    "@rollup/rollup-freebsd-x64" "4.62.4"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.62.4"
+    "@rollup/rollup-linux-arm-musleabihf" "4.62.4"
+    "@rollup/rollup-linux-arm64-gnu" "4.62.4"
+    "@rollup/rollup-linux-arm64-musl" "4.62.4"
+    "@rollup/rollup-linux-loong64-gnu" "4.62.4"
+    "@rollup/rollup-linux-loong64-musl" "4.62.4"
+    "@rollup/rollup-linux-ppc64-gnu" "4.62.4"
+    "@rollup/rollup-linux-ppc64-musl" "4.62.4"
+    "@rollup/rollup-linux-riscv64-gnu" "4.62.4"
+    "@rollup/rollup-linux-riscv64-musl" "4.62.4"
+    "@rollup/rollup-linux-s390x-gnu" "4.62.4"
+    "@rollup/rollup-linux-x64-gnu" "4.62.4"
+    "@rollup/rollup-linux-x64-musl" "4.62.4"
+    "@rollup/rollup-openbsd-x64" "4.62.4"
+    "@rollup/rollup-openharmony-arm64" "4.62.4"
+    "@rollup/rollup-win32-arm64-msvc" "4.62.4"
+    "@rollup/rollup-win32-ia32-msvc" "4.62.4"
+    "@rollup/rollup-win32-x64-gnu" "4.62.4"
+    "@rollup/rollup-win32-x64-msvc" "4.62.4"
+    fsevents "~2.3.2"
 
 rollup@^4.35.0:
   version "4.53.3"
@@ -11216,12 +11955,17 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.2, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -11324,6 +12068,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
 source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
@@ -11368,6 +12117,11 @@ stack-generator@^2.0.5:
   dependencies:
     stackframe "^1.3.4"
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
@@ -11406,6 +12160,19 @@ static-browser-server@1.0.3:
     dotenv "^16.0.3"
     mime-db "^1.52.0"
     outvariant "^1.3.0"
+
+std-env@^3.5.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
+
+stop-iteration-iterator@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz#f481ff70a548f6124d0312c3aa14cbfa7aa542ad"
+  integrity sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==
+  dependencies:
+    es-errors "^1.3.0"
+    internal-slot "^1.1.0"
 
 stream-events@^1.0.5:
   version "1.0.5"
@@ -11608,6 +12375,13 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strip-literal@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-2.1.1.tgz#26906e65f606d49f748454a08084e94190c2e5ad"
+  integrity sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==
+  dependencies:
+    js-tokens "^9.0.1"
+
 stripe@^15.5.0:
   version "15.5.0"
   resolved "https://registry.yarnpkg.com/stripe/-/stripe-15.5.0.tgz#4e7a9b5b6f9ef4b975f1714c14f55ed646b3de05"
@@ -11776,6 +12550,21 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
+tinybench@^2.5.1:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinypool@^0.8.3:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.8.4.tgz#e217fe1270d941b39e98c625dcecebb1408c9aa8"
+  integrity sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==
+
+tinyspy@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-2.2.1.tgz#117b2342f1f38a0dbdcc73a50a454883adf861d1"
+  integrity sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==
+
 title-case@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/title-case/-/title-case-3.0.3.tgz#bc689b46f02e411f1d1e1d081f7c3deca0489982"
@@ -11929,6 +12718,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type-detect@^4.0.0, type-detect@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
+  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
+
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
@@ -12003,6 +12797,11 @@ ua-parser-js@^0.7.30:
   version "0.7.35"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.35.tgz#8bda4827be4f0b1dda91699a29499575a1f1d307"
   integrity sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==
+
+ufo@^1.6.3:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.4.tgz#7a8fb875fcc6382d2c7d0b3692738b0500a92467"
+  integrity sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -12290,6 +13089,54 @@ vfile@^6.0.0:
     unist-util-stringify-position "^4.0.0"
     vfile-message "^4.0.0"
 
+vite-node@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-1.6.1.tgz#fff3ef309296ea03ceaa6ca4bb660922f5416c57"
+  integrity sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.4"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    vite "^5.0.0"
+
+vite@^5.0.0:
+  version "5.4.21"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.21.tgz#84a4f7c5d860b071676d39ba513c0d598fdc7027"
+  integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+  dependencies:
+    esbuild "^0.21.3"
+    postcss "^8.4.43"
+    rollup "^4.20.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-1.6.1.tgz#b4a3097adf8f79ac18bc2e2e0024c534a7a78d2f"
+  integrity sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==
+  dependencies:
+    "@vitest/expect" "1.6.1"
+    "@vitest/runner" "1.6.1"
+    "@vitest/snapshot" "1.6.1"
+    "@vitest/spy" "1.6.1"
+    "@vitest/utils" "1.6.1"
+    acorn-walk "^8.3.2"
+    chai "^4.3.10"
+    debug "^4.3.4"
+    execa "^8.0.1"
+    local-pkg "^0.5.0"
+    magic-string "^0.30.5"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    std-env "^3.5.0"
+    strip-literal "^2.0.0"
+    tinybench "^2.5.1"
+    tinypool "^0.8.3"
+    vite "^5.0.0"
+    vite-node "1.6.1"
+    why-is-node-running "^2.2.2"
+
 void-elements@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
@@ -12429,7 +13276,7 @@ which-builtin-type@^1.2.1:
     which-collection "^1.0.2"
     which-typed-array "^1.1.16"
 
-which-collection@^1.0.2:
+which-collection@^1.0.1, which-collection@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.2.tgz#627ef76243920a107e7ce8e96191debe4b16c2a0"
   integrity sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==
@@ -12443,6 +13290,19 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==
+
+which-typed-array@^1.1.13:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
+  integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
+  dependencies:
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    for-each "^0.3.5"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
 
 which-typed-array@^1.1.16, which-typed-array@^1.1.18:
   version "1.1.18"
@@ -12462,6 +13322,14 @@ which@^2.0.1, which@^2.0.2:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.2.2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
@@ -12641,6 +13509,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
+  integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==
 
 zen-observable-ts@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
## The bug

Checkly `[production-us] app-hosted-pages - walkthrough` intermittently failed its final assertion:
hosted pages never redirected to `success_url` after the checklist was submitted. Reference failure:
2026-08-03 09:14 UTC, session `GpQ2OeoFxwm9`. The backend was blameless — orchestration published
`sessionCompleted` 22 ms after completing the session.

**The measured mechanism** (I reproduced this in a test before changing anything, and it differs from
the original hypothesis in the brief — worth reading if you reviewed that):

1. The `sessionCompleted` frame arrived **while a `GetHostedSession` poll was in flight**.
2. `handleTerminalSession` → `cancelPendingRequests()` aborted that poll.
3. Apollo parked the query observable on the cancellation — `networkStatus: 8` (`error`) — and kept
   serving the **last pre-completion snapshot**.
4. `isTerminated` blocked every subsequent request, so nothing ever reconciled the observable with the
   cache, which *did* hold `COMPLETED`. Matches the trace: zero requests for the remaining 27 s.
5. `useHostedSession` returned `status: ACTIVE` forever → `shouldRedirect` stayed `false` → no redirect.

Two corrections to the original diagnosis, both confirmed by instrumenting the real hook:

| Hypothesis | Measured |
|---|---|
| `useGetHostedSessionQuery` stuck at `loading: true` | `loading: false`, `error: undefined`, **stale** `data` (networkStatus `error`) |
| Skeleton came from `pages/index.tsx` (`sessionLoading`) | Came from `Activities.tsx` (`state === 'polling'`), reachable *only* because the session was stuck `ACTIVE`. The logo is drawn by `HostedPageLayout` in both cases, so the screenshot was ambiguous. |
| Fix = guard the `loading` branch | The `loading` branch was never entered. The final return served stale `data`. |

The brief's **invariant was exactly right**, though: *a terminal status, once known from any source,
must reach the page* — the suppressing state was just staleness rather than `loading`.

Also worth recording: the 30 s Checkly timeout coincides with `ActivityProvider`'s
`DEFAULT_POLLING_TIMEOUT`, so the check died right before the page would have fallen back to a
success page. Long-running sessions would have looked "self-healing" while the check always failed.

## The fix

**Structural choice: independence, plus ordering.** I did both, because they're cheap and complementary:

- **Independence** (the actual fix) — `handleTerminalSession` stores the terminal payload in React
  state, and the hook prefers it over `data?.hostedSession?.session` whenever the query still reports a
  non-terminal status. The redirect no longer depends on the query observable resolving at all. I chose
  this over a `client.readQuery` fallback because `readQuery` returns `null` when the full
  `GetHostedSession` selection isn't satisfied (e.g. the *initial* query was the aborted one), whereas
  the subscription payload is always complete for the fields the redirect needs.
- **Ordering** — `updateHostedSessionQuery` now writes to the cache *before* `handleTerminalSession`
  tears the transport down. Correct invariant, and cheap. **On its own it does not fix the bug** —
  measured: Apollo's `QueryInfo.shouldNotify` suppresses cache-driven notifications while a request is
  in flight, so the write is invisible to the observable either way.
- **Guard** — extended the existing cancellation guard so `loading` can't swallow a known-terminal
  session either. Defence in depth for the initial-query-aborted variant; only changes behaviour when a
  terminal status is already known.

I did **not** narrow the cancel scope or let the poll settle: teardown exists to stop doomed writes
against a dead session (#435), and keeping it a blunt one-way door is easier to reason about than a
per-operation exemption list. `handleTerminalSession` stays idempotent — `handledTerminalSessionRef`
dedup is untouched and `setTerminalSession` sits inside it.

Also extracted `shouldRedirectAfterSession` / `getSessionRedirectUrl` from `pages/index.tsx` so the
redirect condition is asserted in tests against the same predicate production uses.

## How I verified the redirect now fires

`src/hooks/useHostedSession/useHostedSession.test.tsx` reproduces the exact sequence: poll in flight →
`sessionCompleted` frame → `cancelPendingRequests` aborts the poll → assert the hook returns
`status: COMPLETED` with `success_url`, and that `shouldRedirectAfterSession(session)` is `true`. The
test also asserts the preconditions (`inFlightPoll.isAborted()`, `isTerminated`) so it can't silently
stop testing the deadlock.

**With the fix neutralised, 3 of the 7 hook tests fail with `expected 'ACTIVE' to be 'COMPLETED'`** —
i.e. the tests genuinely reproduce the production failure, not just the fixed behaviour. Happy paths
(initial load, completion arriving via the poll instead of the socket) still pass in both states.

Covered: completed, expired (`cancel_url`), branding/theme survival, no-new-requests-after-teardown,
cache contents, and the poll-path happy case.

## Harness (no test infrastructure existed before this)

- **Vitest + React Testing Library + jsdom.** `test/hostedSessionHarness.tsx` mounts
  `HostedSessionProvider` against the **real** `createClient` link chain rather than `MockedProvider`,
  which would replace exactly the layer under test (request-lifecycle links + `AbortController` +
  Apollo's polling observable). Requests stay in flight until the test resolves them, so "a poll is in
  flight right now" is deterministic; aborts reject with a real `AbortError`.
- **CI** — `.github/workflows/ci.yml` runs typecheck + lint + tests on every PR (there was no PR CI at
  all, only deployment workflows). `yarn test` / `test:watch` scripts added; `lint-staged` runs
  `vitest related` so commits stay fast.
- **`CLAUDE.md`** — two-path session model + the invariant, the `cancelPendingRequests` one-way door,
  the corrected render-precedence list (including the *two* distinct `LoadingPage` sites), the Checkly
  diagnosis recipe (`status -1` + no-subsequent-requests = client-side abort), and branch topology.
  Cross-references `.cursor/rules/observability-best-practices.mdc` rather than duplicating it.
- **Observability** for this failure, which previously logged nothing:
  - `GRAPHQL_REQUESTS_ABORTED` — logged when `cancelPendingRequests()` aborts a non-zero number of
    in-flight requests, **with operation names** (abortable requests now carry their operation identity,
    which previously only `settle` requests did).
  - `SESSION_TERMINAL_STATUS_DIVERGED` — the deadlock's fingerprint: push path knows the session ended,
    query still reports otherwise. Would have fired in the reference failure.
  - `SESSION_QUERY_STALLED` — `loading` still true after ~3 poll intervals.

## Verification

- `yarn test` — 21 passing (3 files)
- `yarn tsc --noEmit` — clean
- `yarn lint` — clean (exit 0)
- `yarn build` — succeeds

Branch topology claims in `CLAUDE.md` were verified against `origin`: `main` is an ancestor of every
deploy branch, none is an ancestor of `main`, and `src`/`pages`/`lib` are currently byte-identical
across `main`, `staging`, `production`, `production-us`, `production-uk`. The Checkly CLI commands were
run to confirm their flags.

## Reviewer notes

- `useSessionActivities` still has no coverage. It's the next best candidate now that the harness
  exists, but out of scope here.
- The `SESSION_QUERY_STALLED` warning is a genuine independent guard, but note it would *not* have
  fired for this incident — `loading` was never stuck. `SESSION_TERMINAL_STATUS_DIVERGED` is the one
  that catches this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
